### PR TITLE
Revert "update notebooks"

### DIFF
--- a/examples/example-customer-churn.ipynb
+++ b/examples/example-customer-churn.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -104,12 +104,12 @@
     "# The following code accesses a file in your IBM Cloud Object Storage. It includes your credentials.\n",
     "# You might want to remove those credentials before you share the notebook.\n",
     "client_abc8adf276ed4155b85320acd6c03a69 = ibm_boto3.client(service_name='s3',\n",
-    "    ibm_api_key_id='XXXXX',\n",
+    "    ibm_api_key_id='xxxx',\n",
     "    ibm_auth_endpoint=\"https://iam.ng.bluemix.net/oidc/token\",\n",
     "    config=Config(signature_version='oauth'),\n",
     "    endpoint_url='https://s3-api.us-geo.objectstorage.service.networklayer.com')\n",
     "\n",
-    "body = client_abc8adf276ed4155b85320acd6c03a69.get_object(Bucket='richhproject1-donotdelete-pr-vdi0oj1mgnvqrg',Key='customer-churn-kaggle.csv')['Body']\n",
+    "body = client_abc8adf276ed4155b85320acd6c03a69.get_object(Bucket='xxxx',Key='customer-churn-kaggle.csv')['Body']\n",
     "# add missing __iter__ method, so pandas accepts body as file-like object\n",
     "if not hasattr(body, \"__iter__\"): body.__iter__ = types.MethodType( __iter__, body )\n",
     "\n",
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -347,7 +347,7 @@
        "[5 rows x 21 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -358,16 +358,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7b84631588>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7feb70553470>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -667,7 +667,7 @@
        "max             5.400000                9.000000  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -685,16 +685,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7b842b64a8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7feb701d89e8>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -724,16 +724,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7b83b1d5c0>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7feb6b9e8278>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -763,16 +763,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7b841234e0>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7feb6bfc19e8>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -802,16 +802,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7b8408d208>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7feb6bfa84a8>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -860,9 +860,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "state                       int64\n",
+      "account length              int64\n",
+      "area code                   int64\n",
+      "phone number               object\n",
+      "international plan          int64\n",
+      "voice mail plan             int64\n",
+      "number vmail messages       int64\n",
+      "total day minutes         float64\n",
+      "total day calls             int64\n",
+      "total day charge          float64\n",
+      "total eve minutes         float64\n",
+      "total eve calls             int64\n",
+      "total eve charge          float64\n",
+      "total night minutes       float64\n",
+      "total night calls           int64\n",
+      "total night charge        float64\n",
+      "total intl minutes        float64\n",
+      "total intl calls            int64\n",
+      "total intl charge         float64\n",
+      "customer service calls      int64\n",
+      "churn                        bool\n",
+      "dtype: object\n"
+     ]
+    }
+   ],
    "source": [
     "# Discreet value integer encoder\n",
     "label_encoder = preprocessing.LabelEncoder()\n",
@@ -870,12 +899,14 @@
     "# State, international plans and voice mail plan are strings and we want discreet integer values\n",
     "df['state'] = label_encoder.fit_transform(df['state'])\n",
     "df['international plan'] = label_encoder.fit_transform(df['international plan'])\n",
-    "df['voice mail plan'] = label_encoder.fit_transform(df['voice mail plan'])"
+    "df['voice mail plan'] = label_encoder.fit_transform(df['voice mail plan'])\n",
+    "\n",
+    "print (df.dtypes)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
@@ -1103,7 +1134,7 @@
        "[5 rows x 21 columns]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1122,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1131,7 +1162,7 @@
        "3333"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1150,7 +1181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1354,7 +1385,7 @@
        "4                       3  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1374,7 +1405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1396,7 +1427,7 @@
        "(3333, 19)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1416,7 +1447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1437,7 +1468,7 @@
        "         1.2411686 , -1.1882185 ]])"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1471,7 +1502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1505,7 +1536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1528,7 +1559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1538,7 +1569,7 @@
       "Gradient Boosting Classifier:  0.95\n",
       "Support vector machine(SVM):   0.92\n",
       "Random Forest Classifier:      0.94\n",
-      "K Nearest Neighbor Classifier: 0.89\n",
+      "K Nearest Neighbor Classifier: 0.90\n",
       "Logistic Regression:           0.86\n"
      ]
     }
@@ -1574,12 +1605,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEICAYAAACDGjUCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAGzNJREFUeJzt3XuYFOWZ/vHvPTOACigIiorEI4mLSRa9UPGAQTEgGhcT4yG6QpQEiboeQqLGxHhOzCZmo7+oG6LEU9Tw0xBQUUQ8sILR8UAERANBDSiCgogCIjPz7B9d4zY409MDPdM15f3xqqu733qr6q1xrmcennqrWhGBmZmlS0W5B2BmZp/m4GxmlkIOzmZmKeTgbGaWQg7OZmYp5OBsZpZCDs72CUmvSzoieX+xpJvLPabWJOm/JV1S7nGYgYNzmyHpJEnPSFotaVny/kxJaonjRcTPIuI7m7sfSbtKCklVBfpcJmm9pA+TZZ6k4zb32E2M69uSnspvi4jREXFlSx7XrFgOzm2ApDHAdcAvgR2AHsBo4GCgfSPbVLbaAEvjTxHRKSI6AecBd0rqUe5BmZWLg3PKSdoGuAI4MyLujYgPIufFiDglItYl/W6VdJOkyZJWA4dJOlrSi5JWSVok6bKN9n2qpDckLZf0443WXSbpzrzP/SXNlLRS0t8kDcxb94SkKyXNkPSBpEckdU9WT09eVyZZ8YFNnXNETAE+APbIO8Z3JS2QtELSJEk75a07SFK1pPeT14Py1n1b0sJkXK9JOkXSvwD/DRyYjGll3s/wquT9QEmLJY1J/qWyRNJpefvtJun+5GdbLemqjTNxs83h4Jx+BwIdgIlF9D0ZuBroDDwFrAaGA12Ao4HvSToWQFIf4CbgVGAnoBuwc0M7ldQTeBC4CtgW+AFwn6TtNjr2acD25LL5HyTthyavXZLM+OlCJ6Cco5N9vJy0HQ78HDgB2BF4A7gnWbdtMrbrk3P4NfBgEjw7Ju1DI6IzcBAwKyLmkfuXx9PJmLo0MpwdgG2AnsBI4AZJXZN1N5D7+e4AjEgWs5JxcE6/7sC7EVFT35CXwa6VdGhe34kRMSMi6iLio4h4IiJmJ59fAu4GvpL0/SbwQERMT7LvS4C6Rsbw78DkiJic7Gsq8BxwVF6fP0TE3yNiLTAe6NvM8zwhyWBXA5OAn0XEymTdKcC4iHghGeuPyGW9u5L7ozM/Iu6IiJqIuBt4BTgm2bYO+KKkLSNiSUTMbcaY1gNXRMT6iJgMfAh8ISkZHQdcGhFrIuJl4LZmnq9ZQQ7O6bcc6J5/QS0iDkqyveVs+P9wUf6Gkg6Q9LikdyS9Ty5brC837JTfPyJWJ/tryC7A8ckfhJVJED2EXBZb7+2892uATs05SWB8RHSJiK3IlTOGSzojb6xv5I31w2SsPTdel3gD6Jmc04nkznuJpAcl7dWMMS3P/6PI/53XdkAVG/68N/jZm20uB+f0expYBwwrou/Gjxi8i1wW2isitiFXZ62f3bEE6FXfUdJW5MoCDVkE3JEEz/qlY0RcswljanqDiNeBh/i/7Pctcn8g6sfaMRnrmxuvS3wuWUdETImIr5L7Q/IK8PtNHVeed4AaNiwD9Wqkr9kmcXBOueSf9pcDN0r6pqROkiok9QU6NrF5Z2BFRHwkaX9ydeF69wJfk3SIpPbkLjo29vtwJ3CMpCGSKiVtkVwwa7BGvZF3yJUWdi+iLwDJfo8E6ksQdwGnSeorqQPwM+CZJIhPBj4v6WRJVZJOBPoAD0jqIenfkmC+jlxZojbZ51Jg5+TcmyUiaoE/A5dJ2irJxoc3dz9mhTg4twER8Z/A94ELgGXkAsvvgAuBmQU2PRO4QtIHwE/J1YLr9zkXOItc4FsCvAcsbuT4i8hl7heTC7aLgB9SxO9PRKwhd5FyRlIS6d9I1xOTmRMfAtXADHJ/lIiIaeRq4vclY90DOClZtxz4GjCGXKnjAuBrEfFuMr4x5LLrFeTq7Wcmx3uMXPB/W9K7TZ1HA84md7HwbeAOcvX8dZuwH7MGyQ/bN9t8kn4B7BARnrVhJeHM2WwTSNpL0peTqX/7k5tqN6Hc47LsaPSWWjMrqDO5UsZO5EpN11LcXHSzorisYWaWQi5rmJmlUIuXNda/u9CpuX3KljsNKPcQLIVqPn5zs5+y2JyY06777i3yVMdScOZsZpZCviBoZtlSV9t0nzbAwdnMsqW2puk+bYCDs5llSkRjD1dsWxyczSxb6hyczczSx5mzmVkK+YKgmVkKOXM2M0uf8GwNM7MU8gVBM7MUclnDzCyFfEHQzCyFnDmbmaWQLwiamaWQLwiamaVPhGvOZmbp45qzmVkKuaxhZpZCzpzNzFKodn25R1ASDs5mli0ZKWv4C17NLFuirvilAEm9JD0uaZ6kuZLOTdovk/SmpFnJclTeNj+StEDSq5KG5LUfmbQtkHRRMafhzNnMsqV0mXMNMCYiXpDUGXhe0tRk3X9FxK/yO0vqA5wE7A3sBDwq6fPJ6huArwKLgWpJkyLi5UIHd3A2s2wpUXCOiCXAkuT9B5LmAT0LbDIMuCci1gGvSVoA7J+sWxARCwEk3ZP0LRicXdYws0yJ2vVFL5JGSXoubxnV0D4l7QrsAzyTNJ0t6SVJ4yR1Tdp6AovyNluctDXWXpCDs5llSzNqzhExNiL65S1jN96dpE7AfcB5EbEKuAnYA+hLLrO+tr5rQ6Mp0F6Qyxpmli0lnK0hqR25wPzHiPgzQEQszVv/e+CB5ONioFfe5jsDbyXvG2tvlDNnM8uW0s3WEHALMC8ifp3XvmNet68Dc5L3k4CTJHWQtBvQG3gWqAZ6S9pNUntyFw0nNXUazpzNLFtKlzkfDJwKzJY0K2m7GPiWpL7kShOvA2cARMRcSePJXeirAc6K5ClMks4GpgCVwLiImNvUwR2czSxbSnT7dkQ8RcP14skFtrkauLqB9smFtmuIg7OZZUuNH7ZvZpY+fvCRmVkKZeTZGg7OZpYtzpzNzFLImbOZWQo5czYzSyHP1jAzS6Fo8rEVbYKDs5lli2vOZmYp5OBsZpZCviBoZpZCtbXlHkFJODibWba4rGFmlkIOzmZmKeSas5lZ+kSd5zmbmaWPyxpmZink2RpmZinkzNnMLIUyEpwryj2AtmzJ0nc47ewLOebkUQw75QzuGP8XAF75+z84+bvncdyIszjh9HOY/fKrACx8YxGnjDqffQYewx/uuneDfd0x/i8c+++jc/v504RWPxdrHR06dODpGQ/w/HNT+dusx7j0p2MAOPN73+aVl5+i5uM36data5lH2cZFFL+kmDPnzVBVWckP/+O79PnCnqxevYYTRp7DQfvtw7U33sL3Tj+FAQfux/SZz3Ltjbdw62//k2227sxF54/mselPb7Cf+Qtf575JD3P3zb+hXVU7Ro/5CYcetD+79OpZpjOzlrJu3TqOGHwCq1evoaqqiulPTODhhx9n5tPVPDj5UaZNvbfpnVhhGcmcmwzOkvYChgE9gQDeAiZFxLwWHlvqbdd9W7brvi0AHTtuxe679GLpO8uRxIer1wDw4eo1bN+9GwDdunahW9cuTJ9ZvcF+Fr6+iC/vvRdbbrEFAP36folp02dy+inHt+LZWGtZnfxutGtXRVW7dkQEs2bNLfOoMiQjU+kKljUkXQjcAwh4FqhO3t8t6aKWH17b8eaSpcyb/w++vPcXuPDcM7j2xlsY9PVT+dVvb+a80d8uuO2eu+/C83+bw8r3V7H2o4/4n6ereXvpO60zcGt1FRUVPFf9CEvefIlp06bzbPWL5R5SttTWFr+kWFM155HAfhFxTUTcmSzXAPsn6xokaZSk5yQ9d/Ptd5dyvKm0Zs1azv/xVVx4zhl06tiRP014kAv/YxTTJtzBBeeM4qc//03B7ffY9XOcfsrxfPe8ixn9/Uv4/J67U1lZ2Uqjt9ZWV1dHv/0Gs8tu/div3z7svfcXyj2kTIm6uqKXNGsqONcBOzXQvmOyrkERMTYi+kVEv+8M/9bmjC/11tfUcN6Pr+LowYfx1YEHAzDpoUc5Ink/5PABn1wQLOS4Y4bw///wW2678Zdss3Vn15s/A95/fxVPTp/JkMEDyz2UbKmL4pcUayo4nwdMk/SQpLHJ8jAwDTi35YeXbhHBT3/+G3bfpRcjTvrGJ+3bde9G9YuzAXjm+VlFBdrl760EYMnby5j25AyGHvGVlhm0lVX37tuyzTZbA7DFFlsw6PABvPrqP8o8qoyJuuKXFCt4QTAiHpb0eXJljJ7k6s2LgeqISHfBphW8+NJc7n94Gr332JXjRpwFwLlnjODyC8/hmut+R01tLR3at+fSC84B4N3lKzhx5Dl8uHoNFRUV3Dn+L0z84+/o1LEj5198FStXraKqqoofjzmTbbbuXM5Tsxay4449GHfLb6isrKCiooJ7772fByc/ytlnnc4PxpzJDjtsx4vPP8pDDz/GGaN/WO7htk0pz4iLpWjhuX7r312YjZ+UldSWOw0o9xAshWo+flObu4/VPz2p6JjT8Yp7Nvt4LcXznM0sW1JeriiW7xA0s2wp0QVBSb0kPS5pnqS5ks5N2reVNFXS/OS1a9IuSddLWiDpJUn75u1rRNJ/vqQRxZyGg7OZZUoJp9LVAGMi4l+A/sBZkvoAFwHTIqI3uckR9fd8DAV6J8so4CbIBXPgUuAActfvLq0P6IU4OJtZtpQoc46IJRHxQvL+A2AeuYkRw4Dbkm63Accm74cBt0fOX4EuknYEhgBTI2JFRLwHTAWObOo0HJzNLFuaEZzzb5hLllEN7VLSrsA+wDNAj4hYArkADmyfdOsJLMrbbHHS1lh7Qb4gaGbZ0ozbsiNiLDC2UB9JnYD7gPMiYpXU6ASPhlZEgfaCnDmbWaZEXRS9NEVSO3KB+Y8R8eekeWlSriB5XZa0LwZ65W2+M7kHxTXWXpCDs5llS+lmawi4BZgXEb/OWzUJqJ9xMQKYmNc+PJm10R94Pyl7TAEGS+qaXAgcnLQV5LKGmWVL6R5odDBwKjBb0qyk7WLgGmC8pJHAP4H6Z/tOBo4CFgBrgNMAImKFpCvJPdUT4IqIWNHUwR2czSxbSnT7dkQ8RcP1YoBBDfQP4KxG9jUOGNec4zs4m1m2ZOTZGg7OZpYpUZuN27cdnM0sW5w5m5mlTzFT5NoCB2czyxYHZzOzFMpGydnB2cyyJWqyEZ0dnM0sW7IRmx2czSxbfEHQzCyNnDmbmaWPM2czszRy5mxmlj5RU+4RlIaDs5llSjhzNjNLIQdnM7P0ceZsZpZCDs5mZikUtY1+O3ab4uBsZpnizNnMLIWizpmzmVnqOHM2M0uhCGfOZmap48zZzCyF6jxbw8wsfXxB0MwshRyczcxSKLLxOGcHZzPLFmfOZmYp5Kl0ZmYpVJuR2RoV5R6AmVkpRajopSmSxklaJmlOXttlkt6UNCtZjspb9yNJCyS9KmlIXvuRSdsCSRcVcx4OzmaWKVGnopci3Aoc2UD7f0VE32SZDCCpD3ASsHeyzY2SKiVVAjcAQ4E+wLeSvgW5rGFmmVLK2RoRMV3SrkV2HwbcExHrgNckLQD2T9YtiIiFAJLuSfq+XGhnzpzNLFOakzlLGiXpubxlVJGHOVvSS0nZo2vS1hNYlNdncdLWWHtBDs5mlim1dRVFLxExNiL65S1jizjETcAeQF9gCXBt0t5QnSQKtBfksoaZZUpL34QSEUvr30v6PfBA8nEx0Cuv687AW8n7xtob5czZzDKlLlT0sikk7Zj38etA/UyOScBJkjpI2g3oDTwLVAO9Je0mqT25i4aTmjqOM2czy5RS3oQi6W5gINBd0mLgUmCgpL7kShOvA2fkjhtzJY0nd6GvBjgrImqT/ZwNTAEqgXERMbfJY0cL/xtg/bsLM3Knu5XSljsNKPcQLIVqPn5zsyPrC72GFR1z9l00MbV3rLR45txtlyNa+hDWBu3VtVfTncw2waaWK9LGZQ0zy5TaumxcSnNwNrNMyUod1cHZzDLFZQ0zsxTyI0PNzFIoI1++7eBsZtkSDd4t3fY4OJtZptS4rGFmlj7OnM3MUsg1ZzOzFHLmbGaWQs6czcxSqNaZs5lZ+hT3va3p5+BsZplS58zZzCx9/OAjM7MU8gVBM7MUqpPLGmZmqVNb7gGUiIOzmWWKZ2uYmaWQZ2uYmaWQZ2uYmaWQyxpmZinkqXRmZilU68zZzCx9nDmbmaWQg7OZWQpl5CsEHZzNLFucOZuZpVBWbt+uKPcAzMxKqU7FL02RNE7SMklz8tq2lTRV0vzktWvSLknXS1og6SVJ++ZtMyLpP1/SiGLOw8HZzDKlrhlLEW4Fjtyo7SJgWkT0BqYlnwGGAr2TZRRwE+SCOXApcACwP3BpfUAvxMHZzDKllME5IqYDKzZqHgbclry/DTg2r/32yPkr0EXSjsAQYGpErIiI94CpfDrgf4qDs5llSjRjkTRK0nN5y6giDtEjIpYAJK/bJ+09gUV5/RYnbY21F+QLgmaWKc15tkZEjAXGlujQDR05CrQX5MzZzDKlthnLJlqalCtIXpcl7YuBXnn9dgbeKtBekIOzmWVKHVH0sokmAfUzLkYAE/PahyezNvoD7ydljynAYEldkwuBg5O2glzWMLNMKeVNKJLuBgYC3SUtJjfr4hpgvKSRwD+B45Puk4GjgAXAGuA0gIhYIelKoDrpd0VEbHyR8VMcnM0sU0r5sP2I+FYjqwY10DeAsxrZzzhgXHOO7eBsZpni27fNzFKoRtn4oioHZzPLlGyEZgdnM8sYlzXMzFJoM6bIpYqDs5llSjZCs4OzmWWMyxpmZilUm5Hc2cHZzDLFmbOZWQqFM2czs/Rx5myfcsNNv+DIoYfxzjvL6b/fUACuvPoihg4dxMfr1/Pawjc4c/QFvP/+BwDs/cW9uO76q+jcuRN1EQwcMIx16z4u5ylYibXv0J7bJt5E+/btqaysZOoDj3HDL2/mqusuod9B+/Dhqg8B+PE5V/Lq3PmcduYpHH3cEAAqqyrZvfeuDOgzlFUrV5XzNNqUrEylU+5ZHS1n6467Z+MnVYSDDt6P1avX8Lvf/+qT4Hz4oEN48omnqa2t5fIrLwTg0kt+QWVlJf8z835Gfef7zJn9Cttu24WVK1dRV5eVv/uFfa7T9k13yogtt9qStWvWUlVVye33j+Wan/yaE4Z/gyenPsXUBx5vdLuvDD6E4WecxMjjzm7F0ZbXnKV/bcaj8hv2vV1PKDrm3PT6+M0+Xkvx85xLaOaMat5bsXKDtsemPUVtbe6x3tXPvkjPnjsAMOiIAcyd8wpzZr8CwIoVKz8zgfmzZu2atQBUtauiqqqKYvOho77+VSZPmNqCI8umGqLoJc0cnFvRqcOPZ+ojTwCw5567ERFMmHgr02dM4tzzi/nqMmuLKioquHfa7Uyf+xBPP/kss1+YC8A5PxrNnx+/kwuuOJd27dttsM0WW3bgkMP6F8ysrWHRjP/SbJODs6TTCqz75EsTP65xrQzgBz88k5qaGv50T+5LEyqrKul/YD9Gnn4+Q444gWOOGcxXBh5U5lFaS6irq+Obg4YzqO+/8aV9+7DnXrvzm6tv5JiDT+TEIaexTZetGXn2qRtsM3DwAF6snu1a8yYo5bdvl9PmZM6XN7YiIsZGRL+I6Ne+auvNOEQ2nHzKNzhy6OF85/TzP2l76823mfHUM6xY/h5r137EI1Oe4F/77l3GUVpL+2DVh1TPeIFDDuvPu8uWA7D+4/X85Z4H+dK+fTboO/TYI5g84ZFyDLPN+0xkzpJeamSZDfRopTG2aUd89VDOO/8MTjxhFGvXfvRJ+7RHp7P3F/diyy23oLKykoMHHMCr8xaUcaTWErp260LnrTsB0GGLDvQ/dD9eW/AG3bfv9kmfw4ceyvxXFn7yuVPnjvQ7cB8ef3h6q483C7KSOTc1la4HMAR4b6N2ATNbZERt2Lhbr+OQAQfQrVtX5v19Bj+76jrG/GA07Tu0Z+L9twNQ/ewszj/3J6xcuYob/t8tPDH9LwTBI1OeYMoU1xezZrse3bn6+kuorKxEFWLKxGk8OXUGt9z3W7p264IkXp0zn8t/+ItPthl01EBmPvksa9d8VGDP1pjaFp6B1loKTqWTdAvwh4h4qoF1d0XEyU0d4LM0lc6K91maSmfFK8VUupN3+XrRMeeuNyakdipdwcw5IkYWWNdkYDYza21pryUXy3cImlmmpL2WXCwHZzPLlKzcvu3gbGaZ4rKGmVkKZWW2hoOzmWWKyxpmZinkC4JmZinkmrOZWQq5rGFmlkIt/QUircXPczazTKklil6aIul1SbMlzZL0XNK2raSpkuYnr12Tdkm6XtKC5AFx+27OeTg4m1mm1BFFL0U6LCL6RkS/5PNFwLSI6A1MSz4DDAV6J8so4KbNOQ8HZzPLlIgoetlEw4Dbkve3Acfmtd8eOX8FukjacVMP4uBsZpnSnMw5/1ubkmXj74sL4BFJz+et6xERSwCS1/pHLPYEFuVtuzhp2yS+IGhmmdKcqXQRMRYYW6DLwRHxlqTtgamSXinQt6HHj25yeu7gbGaZUsrbtyPireR1maQJwP7AUkk7RsSSpGyxLOm+GOiVt/nOwFubemyXNcwsU0p1QVBSR0md698Dg4E5wCRgRNJtBDAxeT8JGJ7M2ugPvF9f/tgUzpzNLFNKeBNKD2CCJMjFyrsi4mFJ1cB4SSOBfwLHJ/0nA0cBC4A1wGmbc3AHZzPLlFLdhBIRC4F/baB9OTCogfYAzirJwXFwNrOM8e3bZmYp5AcfmZmlUG1k46GhDs5mlilZefCRg7OZZYprzmZmKeSas5lZCtW5rGFmlj7OnM3MUsizNczMUshlDTOzFHJZw8wshZw5m5mlkDNnM7MUqo3acg+hJByczSxTfPu2mVkK+fZtM7MUcuZsZpZCnq1hZpZCnq1hZpZCvn3bzCyFXHM2M0sh15zNzFLImbOZWQp5nrOZWQo5czYzSyHP1jAzSyFfEDQzSyGXNczMUsh3CJqZpZAzZzOzFMpKzVlZ+SvTFkgaFRFjyz0OSxf/XlhDKso9gM+YUeUegKWSfy/sUxyczcxSyMHZzCyFHJxbl+uK1hD/Xtin+IKgmVkKOXM2M0shB2czsxRycG4lko6U9KqkBZIuKvd4rPwkjZO0TNKcco/F0sfBuRVIqgRuAIYCfYBvSepT3lFZCtwKHFnuQVg6OTi3jv2BBRGxMCI+Bu4BhpV5TFZmETEdWFHucVg6OTi3jp7AorzPi5M2M7MGOTi3DjXQ5jmMZtYoB+fWsRjolfd5Z+CtMo3FzNoAB+fWUQ30lrSbpPbAScCkMo/JzFLMwbkVREQNcDYwBZgHjI+IueUdlZWbpLuBp4EvSFosaWS5x2Tp4du3zcxSyJmzmVkKOTibmaWQg7OZWQo5OJuZpZCDs5lZCjk4m5mlkIOzmVkK/S9NUMEu4Hot9gAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEICAYAAACDGjUCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAGzxJREFUeJzt3XucVWXZ//HPl+GgAgqCohwSNdQon9DUSM08lIKHqMxzSh4CU/OQ5jHzXHbA0t+jJCaJIhI/zUDFjFAzPGLmoyIqhCkjBAKeEFNmz/X8sdfwbGFmzwwMs+9Zfd++1mvvfa97rXWvcV7XXFzrXmsrIjAzs7S0q/QAzMxsTQ7OZmYJcnA2M0uQg7OZWYIcnM3MEuTgbGaWIAdnW0XSPyV9OXt/oaTfVHpMrUnSryVdXOlxmIGDc5sh6UhJT0p6X9Li7P0pkrQ+jhcRP46Ik9Z1P5L6SwpJ7cv0uVTSSknLs2W2pEPX9diNjOvbkmaUtkXEyRFxxfo8rllTOTi3AZLOBq4Ffg5sAfQCTgb2ADo2sE1Vqw2wZfwuIrpERBfgTGC8pF6VHpRZpTg4J07SJsDlwCkRcWdEvBdFf4+IYyLiw6zfLZJGS5oq6X1gH0kHSfq7pHclzZd06Wr7PlbSa5KWSrpotXWXShpf8nmwpMckvS3pfyTtXbLuYUlXSHpU0nuS/iSpZ7b6kez17Swr/kJj5xwRDwDvAduWHOM7kuZKWiZpiqTeJet2lzRT0jvZ6+4l674taV42rlclHSPpU8CvgS9kY3q75Gd4ZfZ+b0nVks7O/qWyUNLxJfvtIeme7Gc7U9KVq2fiZuvCwTl9XwA6AZOb0Pdo4CqgKzADeB84DugGHAR8V9LXACQNBEYDxwK9gR5A3/p2KqkPcB9wJbApcA5wl6TNVjv28cDmFLP5c7L2vbLXbllm/Hi5E1DRQdk+Xsza9gV+AhwObAm8BkzM1m2aje267ByuAe7LgmfnrH1oRHQFdgeejYjZFP/l8Xg2pm4NDGcLYBOgD3AicL2k7tm66yn+fLcAhmeLWYtxcE5fT2BJRNTUNZRksB9I2quk7+SIeDQiaiPi3xHxcEQ8n31+DrgD+FLW95vAvRHxSJZ9XwzUNjCGbwFTI2Jqtq9pwNPAgSV9fhsRr0TEB8AkYFAzz/PwLIN9H5gC/Dgi3s7WHQOMjYhnsrFeQDHr7U/xj86ciLgtImoi4g7gJeCQbNta4DOSNoyIhRExqxljWglcHhErI2IqsBzYPisZHQpcEhErIuJFYFwzz9esLAfn9C0FepZeUIuI3bNsbykf/384v3RDSZ+X9JCkNyW9QzFbrCs39C7tHxHvZ/urz1bAYdkfhLezILonxSy2zr9K3q8AujTnJIFJEdEtIjaiWM44TtLIkrG+VjLW5dlY+6y+LvMa0Cc7pyMonvdCSfdJ2qEZY1pa+keR/zuvzYD2fPzn/bGfvdm6cnBO3+PAh8CwJvRd/RGDEyhmof0iYhOKdda62R0LgX51HSVtRLEsUJ/5wG1Z8KxbOkfE1WsxpsY3iPgncD//l/0uoPgHom6snbOxvrH6uswnsnVExAMR8RWKf0heAm5a23GVeBOo4eNloH4N9DVbKw7Oicv+aX8ZcIOkb0rqIqmdpEFA50Y27wosi4h/S9qNYl24zp3AwZL2lNSR4kXHhn4fxgOHSDpAUpWkDbILZvXWqFfzJsXSwjZN6AtAtt8hQF0JYgJwvKRBkjoBPwaezIL4VGA7SUdLai/pCGAgcK+kXpK+mgXzDymWJQrZPhcBfbNzb5aIKAC/By6VtFGWjR/X3P2YlePg3AZExM+A7wPnAospBpYbgfOAx8psegpwuaT3gB9RrAXX7XMWcCrFwLcQeAuobuD48ylm7hdSDLbzgR/QhN+fiFhB8SLlo1lJZHADXY/IZk4sB2YCj1L8o0RETKdYE78rG+u2wJHZuqXAwcDZFEsd5wIHR8SSbHxnU8yul1Gst5+SHe9BisH/X5KWNHYe9TiN4sXCfwG3Uaznf7gW+zGrl/ywfbN1J+mnwBYR4Vkb1iKcOZutBUk7SPqvbOrfbhSn2t1d6XFZfjR4S62ZldWVYimjN8VS0yiaNhfdrElc1jAzS5DLGmZmCVrvZY2VS+Y5Nbc1bNj7i5UegiWo5qM31vkpi82JOR16brNenurYEpw5m5klyBcEzSxfaguN92kDHJzNLF8KNY33aQMcnM0sVyIaerhi2+LgbGb5UuvgbGaWHmfOZmYJ8gVBM7MEOXM2M0tPeLaGmVmCfEHQzCxBLmuYmSXIFwTNzBLkzNnMLEG+IGhmliBfEDQzS0+Ea85mZulxzdnMLEEua5iZJciZs5lZggorKz2CFuHgbGb5kpOyhr/g1czyJWqbvpQhqZ+khyTNljRL0hlZ+6WS3pD0bLYcWLLNBZLmSnpZ0gEl7UOytrmSzm/KaThzNrN8abnMuQY4OyKekdQV+Jukadm6X0bEL0o7SxoIHAl8GugN/FnSdtnq64GvANXATElTIuLFcgd3cDazfGmh4BwRC4GF2fv3JM0G+pTZZBgwMSI+BF6VNBfYLVs3NyLmAUiamPUtG5xd1jCzXInCyiYvkkZIerpkGVHfPiX1B3YCnsyaTpP0nKSxkrpnbX2A+SWbVWdtDbWX5eBsZvnSjJpzRIyJiF1KljGr705SF+Au4MyIeBcYDWwLDKKYWY+q61rfaMq0l+WyhpnlSwvO1pDUgWJgvj0ifg8QEYtK1t8E3Jt9rAb6lWzeF1iQvW+ovUHOnM0sX1putoaAm4HZEXFNSfuWJd2+DryQvZ8CHCmpk6StgQHAU8BMYICkrSV1pHjRcEpjp+HM2czypeUy5z2AY4HnJT2btV0IHCVpEMXSxD+BkQARMUvSJIoX+mqAUyN7CpOk04AHgCpgbETMauzgDs5mli8tdPt2RMyg/nrx1DLbXAVcVU/71HLb1cfB2czypcYP2zczS48ffGRmlqCcPFvDwdnM8sWZs5lZgpw5m5klyJmzmVmCPFvDzCxB0ehjK9oEB2czyxfXnM3MEuTgbGaWIF8QNDNLUKFQ6RG0CAdnM8sXlzXMzBLk4GxmliDXnM3M0hO1nudsZpYelzXMzBLk2RpmZgly5mxmlqCcBOd2lR5AW7Zw0Zscf9p5HHL0CIYdM5LbJv0BgJde+QdHf+dMDh1+KoefcDrPv/gyAPNem88xI85ip70P4bcT7vzYvmY88TQHH3kSQw8/gd/cNqnVz8VaT7t27Zj51ANMvnscAP379+OxGfcwe9YMJtw+mg4dOlR4hG1cRNOXhDk4r4P2VVX84Hvf4Z4JY5gw5pdM/P29/OPV1xh1w81894RjuGvc9Zx20rcYdcPNAGyycVfOP+tkvn3UoR/bT6FQ4MpR1zN61BVMuf1Gpv75Yf7x6muVOCVrBad/7yReemnOqs8/+fFF/Oq6m/jUp/fkrbfe4YTjj6rg6HKgtrbpS8IaDc6SdpB0nqTrJF2bvf9UawwudZv13JSB238SgM6dN2Kbrfqx6M2lSGL5+ysAWP7+Cjbv2QOAHt27seOntqd9+49Xk56f/Qqf6Nubfn22pEOHDgzd70s8+NcnWvdkrFX06bMlBw7dj7Fj71jVts/ee3DXXfcBcNtt/59hXz2gUsPLh9po+pKwsjVnSecBRwETgaey5r7AHZImRsTV63l8bcYbCxcxe84/+K9Pb895Z4xk5Pd/yC+u/w1RG4y/cVTZbRe/uYQtNt9s1edem/fk+Vkvr+8hWwVcM+oyzr/gSrp27QJAjx7defvtdyhkMwyq31hI7z5bVHKIbV9OZms0ljmfCOwaEVdHxPhsuRrYLVtXL0kjJD0t6enf3HpHQ91yY8WKDzjrois57/SRdOncmd/dfR/nfW8E0+++jXNPH8GPfvKrstvXV/qS1tNgrWIOOvDLLF68hGf+/vyqNtXzPzoSr4WmLmprm7ykrLHZGrVAb2D1AuiW2bp6RcQYYAzAyiXzcv2btrKmhjMvupKD9t+Hr+y9BwBT7v8zF5x5MgAH7PtFLrm6fHDutXlP/rX4zVWfFy1ewmZZKcTyY/fdd+GQg/dn6JB92WCDTmy8cVeuGXUZ3bptQlVVFYVCgb59tmThgkWVHmrblni5oqkay5zPBKZLul/SmGz5IzAdOGP9Dy9tEcGPfvIrttmqH8OP/Maq9s169mBmlh09+bdn2apfn7L7+cwO2/F69QKqF/yLlStXcv/0v7DPnoPX69it9V30w6vpv80ufHK7wRzzrVN46KFHOW7493j4L49x6KEHAXDssYcx5Z4/VXikbVzUNn1JWNnMOSL+KGk7imWMPoCAamBmROSjsLMO/v7cLO7543QGbNufQ4efCsAZI4dz2Xmnc/W1N1JTKNCpY0cuOfd0AJYsXcYRJ57O8vdX0K5dO8ZP+gOTb7+RLp07c+FZ32Xk939IoVDg6wfvzye32aqSp2at6IILr2LC+Bu4/NJzefZ/ZjH2t/kvBa5XOcmctb7rW3kva9ja2bD3Fys9BEtQzUdvrPPVlvd/dGSTY07nyycme3XHdwiaWb4kXq5oKt+EYmb50kLznCX1k/SQpNmSZkk6I2vfVNI0SXOy1+5Zu7L7QeZKek7SziX7Gp71nyNpeFNOw8HZzHKlBafS1QBnR8SngMHAqZIGAucD0yNiAMXJEedn/YcCA7JlBDAaisEcuAT4PMXrd5fUBfRyHJzNLF9aKHOOiIUR8Uz2/j1gNsWJEcOAcVm3ccDXsvfDgFuj6Amgm6QtgQOAaRGxLCLeAqYBQxo7DQdnM8uXZgTn0hvmsmVEfbuU1B/YCXgS6BURC6EYwIHNs259gPklm1VnbQ21l+ULgmaWL824fbv0hrmGSOoC3AWcGRHv1ndXZ13X+g5Rpr0sZ85mlitRG01eGiOpA8XAfHtE/D5rXpSVK8heF2ft1UC/ks37AgvKtJfl4Gxm+dJyszUE3AzMjohrSlZNAepmXAwHJpe0H5fN2hgMvJOVPR4A9pfUPbsQuH/WVpbLGmaWLy33QKM9gGOB5yU9m7VdCFwNTJJ0IvA6cFi2bipwIDAXWAEcDxARyyRdAczM+l0eEcsaO7iDs5nlSwvdvh0RM6i/XgywXz39Azi1gX2NBcY25/gOzmaWLzl5toaDs5nlShTycfu2g7OZ5YszZzOz9DRlilxb4OBsZvni4GxmlqB8lJwdnM0sX6ImH9HZwdnM8iUfsdnB2czyxRcEzcxS5MzZzCw9zpzNzFLkzNnMLD1RU+kRtAwHZzPLlXDmbGaWIAdnM7P0OHM2M0uQg7OZWYKi0OC3Y7cpDs5mlivOnM3MEhS1zpzNzJLjzNnMLEERzpzNzJLjzNnMLEG1nq1hZpYeXxA0M0uQg7OZWYIiH49zdnA2s3xx5mxmliBPpTMzS1AhJ7M12lV6AGZmLSlCTV4aI2mspMWSXihpu1TSG5KezZYDS9ZdIGmupJclHVDSPiRrmyvp/Kach4OzmeVK1KrJSxPcAgypp/2XETEoW6YCSBoIHAl8OtvmBklVkqqA64GhwEDgqKxvWS5rmFmutORsjYh4RFL/JnYfBkyMiA+BVyXNBXbL1s2NiHkAkiZmfV8stzNnzmaWK83JnCWNkPR0yTKiiYc5TdJzWdmje9bWB5hf0qc6a2uovSwHZzPLlUJtuyYvETEmInYpWcY04RCjgW2BQcBCYFTWXl+dJMq0l+Wyhpnlyvq+CSUiFtW9l3QTcG/2sRroV9K1L7Age99Qe4OcOZtZrtSGmrysDUlblnz8OlA3k2MKcKSkTpK2BgYATwEzgQGStpbUkeJFwymNHceZs5nlSkvehCLpDmBvoKekauASYG9JgyiWJv4JjCweN2ZJmkTxQl8NcGpEFLL9nAY8AFQBYyNiVqPHjvX8b4CVS+bl5E53a0kb9v5ipYdgCar56I11jqzP9BvW5Jiz8/zJyd6xst4z5x5bfXl9H8LaoB2692u8k9laWNtyRWpc1jCzXCnU5uNSmoOzmeVKXuqoDs5mlisua5iZJciPDDUzS1BOvnzbwdnM8iXqvVu67XFwNrNcqXFZw8wsPc6czcwS5JqzmVmCnDmbmSXImbOZWYIKzpzNzNLTtO9tTZ+Ds5nlSq0zZzOz9PjBR2ZmCfIFQTOzBNXKZQ0zs+QUKj2AFuLgbGa54tkaZmYJ8mwNM7MEebaGmVmCXNYwM0uQp9KZmSWo4MzZzCw9zpzNzBLk4GxmlqCcfIWgg7OZ5YszZzOzBOXl9u12lR6AmVlLqlXTl8ZIGitpsaQXSto2lTRN0pzstXvWLknXSZor6TlJO5dsMzzrP0fS8Kach4OzmeVKbTOWJrgFGLJa2/nA9IgYAEzPPgMMBQZkywhgNBSDOXAJ8HlgN+CSuoBejoOzmeVKSwbniHgEWLZa8zBgXPZ+HPC1kvZbo+gJoJukLYEDgGkRsSwi3gKmsWbAX4ODs5nlSjRjkTRC0tMly4gmHKJXRCwEyF43z9r7APNL+lVnbQ21l+ULgmaWK815tkZEjAHGtNCh6ztylGkvy5mzmeVKoRnLWlqUlSvIXhdn7dVAv5J+fYEFZdrLcnA2s1ypJZq8rKUpQN2Mi+HA5JL247JZG4OBd7KyxwPA/pK6ZxcC98/aynJZw8xypSVvQpF0B7A30FNSNcVZF1cDkySdCLwOHJZ1nwocCMwFVgDHA0TEMklXADOzfpdHxOoXGdfg4GxmudKSD9uPiKMaWLVfPX0DOLWB/YwFxjbn2A7OZpYrvn3bzCxBNcrHF1U5OJtZruQjNDs4m1nOuKxhZpagdZgilxQHZzPLlXyEZgdnM8sZlzXMzBJUyEnu7OBsZrnizNnMLEHhzNnMLD3OnG0N14/+KUOG7sObby5l8K5DAbjiqvMZOnQ/Plq5klfnvcYpJ5/LO++8R/v27fnvG37CZwd9hvZVVdxxx91c84vRFT4Da2kdO3Vk3OTRdOzYkaqqKqbd+yDX//w3XHntxeyy+04sf3c5ABedfgUvz5rDrrvvzHXjfsYbrxefKPnn+x7m19c065EM//E8lc7WcPv4Oxlz463ceNMvVrU99OAMLv3RzykUClx2xXl8/5xTuOTin/L1bxxIp44d+cJuQ9lwww146m9/4s5JU3j99TcqeAbW0j768CNO+MZpfLDiA9q3r+LWe8bw1wcfB2DUZf+Pafc+tMY2zzz5LKd+65zWHmpu5CM0+3nOLeqxR2fy1rK3P9b24PQZFArFx3rPfOrv9OmzBQARwUadN6KqqooNN9yAlR+t5L33lrf6mG39+2DFBwC079Ce9u3bE3mJHomqIZq8pMzBuRUde9xhTPvTwwD84e77WfH+Cub84wlmvTSD6669ibfeeqeyA7T1ol27dtw5/VYemXU/j//lKZ5/ZhYAp19wMr9/aDznXn4GHTp2WNX/s5/bkbsevI3RE37JtttvXalht1nRjP9SttbBWdLxZdat+tLEj2reXdtD5Mo5PziFmpoafjex+KUJn9vlsxRqa9nuk19gx09/ie+dfhL9+/drZC/WFtXW1vLN/Y5jv0FfZcedB/LJHbbhV1fdwCF7HMERBxzPJt025sTTjgXgxede4iuf+xqH7nssE26exHW3/KzCo297WvLbtytpXTLnyxpaERFjImKXiNilY/uN1+EQ+XD0Md9gyNB9OemEs1a1HX74V/nztL9QU1PDkjeX8sQTf2OnnXes4ChtfXvv3eXMfPQZ9txnMEsWLwVg5Ucr+cPE+9hx54EAvL98xaoyyF+nP0779u3ptukmFRtzW/QfkTlLeq6B5XmgVyuNsU378lf24syzRnLE4SP44IN/r2qfX72Avb60OwAbbbQhu+46iFdemVepYdp60r1HN7pu3AWATht0YvBeu/Lq3NfouXmPVX32HboXc14q/r/vsdmmq9o/s9NA2rUTby9zuas58pI5NzZboxdwAPDWau0CHlsvI2rDxt5yLXt+8fP06NGd2a88yo+vvJazzzmZjp06MvmeWwGY+dSznHXGD7npxtu44dc/48mZf0QS48ffyawXXqrwGVhL26xXT6667mKqqqpQO/HA5On8Zdqj3HzXf9O9Rzck8fILc7jsBz8FYP9D9uWI4d+gUCjw739/yA9GXlzhM2h7Cjm54qoocyKSbgZ+GxEz6lk3ISKObuwAG3feJh8/KWtRn+iyeaWHYAl6YdETWtd9HL3V15sccya8dvc6H299KZs5R8SJZdY1GpjNzFpb6rXkpvJNKGaWK6nXkpvKwdnMcsW3b5uZJchlDTOzBOVltoaDs5nlissaZmYJ8gVBM7MEueZsZpYglzXMzBJU7q7ntsTB2cxypZCTzNkP2zezXKklmrw0RtI/JT0v6VlJT2dtm0qaJmlO9to9a5ek6yTNzZ7eufO6nIeDs5nlSkQ0eWmifSJiUETskn0+H5geEQOA6dlngKHAgGwZAazTNzY7OJtZrrRk5tyAYcC47P044Gsl7bdG0RNAN0lbru1BHJzNLFea800opV+ply0j1tgd/EnS30rW9YqIhQDZa93zb/sA80u2rc7a1oovCJpZrjTn9u2IGAOMKdNlj4hYIGlzYJqkct+IUd+zodc6PXfmbGa50pJljYhYkL0uBu4GdgMW1ZUrstfFWfdqoPRbmvsCC9b2PByczSxXWio4S+osqWvde2B/4AVgCjA86zYcmJy9nwIcl83aGAy8U1f+WBsua5hZrrTgTSi9gLslQTFWToiIP0qaCUySdCLwOnBY1n8qcCAwF1gBHL8uB3dwNrNcaanbtyNiHvDZetqXAvvV0x7AqS1ycByczSxn/OAjM7MEFSIfDw11cDazXPGDj8zMEuRHhpqZJcg1ZzOzBNW6rGFmlh5nzmZmCfJsDTOzBLmsYWaWIJc1zMwS5MzZzCxBzpzNzBJUiEKlh9AiHJzNLFd8+7aZWYJ8+7aZWYKcOZuZJcizNczMEuTZGmZmCfLt22ZmCXLN2cwsQa45m5klyJmzmVmCPM/ZzCxBzpzNzBLk2RpmZgnyBUEzswS5rGFmliDfIWhmliBnzmZmCcpLzVl5+SvTFkgaERFjKj0OS4t/L6w+7So9gP8wIyo9AEuSfy9sDQ7OZmYJcnA2M0uQg3Prcl3R6uPfC1uDLwiamSXImbOZWYIcnM3MEuTg3EokDZH0sqS5ks6v9His8iSNlbRY0guVHoulx8G5FUiqAq4HhgIDgaMkDazsqCwBtwBDKj0IS5ODc+vYDZgbEfMi4iNgIjCswmOyCouIR4BllR6HpcnBuXX0AeaXfK7O2szM6uXg3DpUT5vnMJpZgxycW0c10K/kc19gQYXGYmZtgINz65gJDJC0taSOwJHAlAqPycwS5uDcCiKiBjgNeACYDUyKiFmVHZVVmqQ7gMeB7SVVSzqx0mOydPj2bTOzBDlzNjNLkIOzmVmCHJzNzBLk4GxmliAHZzOzBDk4m5klyMHZzCxB/wtf+9RfABG2JQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 2 Axes>"
       ]
@@ -1606,12 +1637,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEICAYAAACDGjUCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAF+tJREFUeJzt3XuYlWW9//H3Z0BIwRJEEZFEjSy0Un94aBuFhxBt/0TT/KFtJaXG2pLaZZ5/ZaKWlaiZhx0qiuYhREgSxZBULFLBQwgiMOKBUQIV8gAqzMx3/zEP7LVhWLOANbPuefy8uu5r1tzPvZ7nXl5zffn2ve/nWYoIzMwsLVWVnoCZma3PwdnMLEEOzmZmCXJwNjNLkIOzmVmCHJzNzBLk4GxmliAHZysbSV+RNF3SO5KWSfqbpP6SVkjauonxz0oaLqm3pJD0zDrHu0laJemVVvsQZolwcLaykPRJ4H7gt0BXoCdwMfAOUAscs874PYG+wF0F3Z2y/jVOAF5uwWmbJcvB2crlswARcVdE1EfEBxHx54iYBYwBTlpn/EnApIh4u6DvdmDoOmNua8lJm6XKwdnKZT5QL2mMpMMldSk4djvQX9KnASRV0ZgVrxt4fw8MkdRO0ueBrYEnW2HuZslxcLayiIh3ga8AAdwIvClpoqTuEbEIeAz4j2z4IcAngEnrnKYWmAccSmMG7azZPrYcnK1sImJuRHwnInYC9gR2BK7ODheWNk4E7oyI1U2c5jbgO8DxNGbSZh9LDs7WIiLiReBWGoM0wHigp6SDgG+y4az4XuAbwMKIeLWl52mWqvaVnoDlg6TP0RhU/xARtZJ60Zj9PgEQESskjQNuAV6NiJlNnScbdzCwvJWmbpYkZ85WLu8B+wNPSlpBY1CeDZxVMGYMsDPN1JIjYmZEvNRSEzVrC+SH7ZuZpceZs5lZghyczcwS5OBsZpYgB2czswS1+Fa61W8t9IqjrWfLHftXegqWoLpVr2tzz7ExMWeLbrtu9vVaijNnM7ME+SYUM8uXhvpKz6AsHJzNLF/q6yo9g7JwcDazXIloqPQUysLB2czypcHB2cwsPc6czcwS5AVBM7MEOXM2M0tPeLeGmVmCvCBoZpYglzXMzBLkBUEzswQ5czYzS5AXBM3MEuQFQTOz9ES45mxmlh7XnM3MEuSyhplZgpw5m5klqH51pWdQFg7OZpYvOSlr+AtezSxfoqH0VoSkXpIekTRX0hxJZ2T9P5P0uqTnsnZEwXvOl1QjaZ6kwwr6B2V9NZLOK+VjOHM2s3wpX+ZcB5wVEc9I2hp4WtKU7NhVEXFF4WBJfYEhwB7AjsDDkj6bHb4O+DpQC8yQNDEiXih2cQdnM8uXMgXniFgMLM5evydpLtCzyFsGA3dHxEfAy5JqgP2yYzURsRBA0t3Z2KLB2WUNM8uVqF9dcpNULWlmQatu6pySegN7A09mXcMlzZI0WlKXrK8nsKjgbbVZ34b6i3JwNrN82Yiac0SMioh+BW3UuqeT1Bm4FzgzIt4FbgB2A/aiMbMeuWZoU7Mp0l+Uyxpmli9l3K0haQsaA/MdETEeICKWFBy/Ebg/+7UW6FXw9p2AN7LXG+rfIGfOZpYv5dutIeBmYG5EXFnQ36Ng2NHA7Oz1RGCIpI6SdgH6AE8BM4A+knaR1IHGRcOJzX0MZ85mli/ly5wPBE4Enpf0XNZ3AXC8pL1oLE28ApwKEBFzJI2lcaGvDjgtsqcwSRoOPAS0A0ZHxJzmLu7gbGb5UqbbtyPirzRdL36gyHsuAy5rov+BYu9rioOzmeVLnR+2b2aWHj/4yMwsQTl5toaDs5nlizNnM7MEOXM2M0uQM2czswR5t4aZWYKi2cdWtAkOzmaWL645m5klyMHZzCxBXhA0M0tQfX2lZ1AWDs5mli8ua5iZJcjB2cwsQa45m5mlJxq8z9nMLD0ua5iZJci7NczMEuTM2cwsQQ7OtnjJm1xwyRW8tWw5VRLHDj6cE487ihfnv8SIX/+Wj1atpl27dvzkx6fxhb67s/DVRfzksit5YX4Np1cP5eQTjl17roHHDKXTVltRVVVFu3btGDv6mgp+MmspHTt25NG/3EuHjh1p374d48dP4uIRI7n5pqv4av8DeOfd9wAY9t0f8Y9/NPsFzdYUP/jI2rdrx9k//B59d/8MK1as5Lhhp/Nv++7NyOtv5genfJv+X96XadOfYuT1N3Prtb/iU5/cmvN+9H3+Mu3vTZ5v9G8vp8s2n2rlT2Gt6aOPPuLQgcexYsVK2rdvz7RHJzB58iMAnHv+pYwfP6nCM8yBj0vmLOlzwGCgJxDAG8DEiJjbwnNL3nbdurJdt64AdOq0Fbvu3Islb76NJN5fsRKA91esZPtu2wKwbZdt2LbLNkybPqNic7bKW5H9bWyxRXvab7EFkZNMLxk52UpXVeygpHOBuwEBTwEzstd3STqv5afXdry+eAlzF7zEF/fYnXPPOJWR19/MIUefyBXX3sSZ3/9Os++XRPWPLuS4U37IPfc90PITtoqpqqpi5ow/s/j1WUydOo2nZjwLwCUjzuWZp6cw8tc/o0OHDhWeZRtWX196S1jR4AwMA/aNiMsj4vdZuxzYLzvWJEnVkmZKmnnTbXeVc75JWrnyA3504aWce/qpdO7UiT9MmMS5P6xm6oTbOef0an76i6ubPcftN4zknluu5YaRl3DX+PuZ+dzzrTBzq4SGhgb67TuQnXfpx7799maPPXbnwv//C/bY86sc8OVv0KXrNpxz9n9WepptVjQ0lNxS1lxwbgB2bKK/R3asSRExKiL6RUS/7550/ObML3mr6+o488JL+cbAg/j6gAMBmPjgwxyavT7s4P48/8K8Zs+z/Xb/U/o45Kv/VtJ7rG175513eWzadA4bOIB//nMpAKtWrWLMmD+wb7+9Kzy7NqwhSm8Jay44nwlMlfSgpFFZmwxMBc5o+emlLSL46S+uZtedezF0yDfX9m/XbVtmPNuY+T759HPs3Ktn0fOs/ODDtXXIlR98yPSnnqHPrr1bbN5WOd26deVTn/okAJ/4xCc45OD+zJv3EjvssP3aMUceOYg5L7xYqSm2fdFQektY0QXBiJgs6bM0ljF60lhvrgVmRETaBZtW8OysOfxp8lT67NabY4aeBsAZpw7l4nNP5/Lf/I66+no6dujAReecDsBbby/j/w07nfdXrKSqqorfj/0j993xO5b/613OuOASAOrr6jli4AC+ckC/in0uazk9enRn9M1X065dFVVVVYwb9ycmPfAwUx4aS7ftuiKJf/xjDv95mpd0NlniGXGp1NIrxavfWpiP/1JWVlvu2L/SU7AE1a16XZt7jhU/HVJyzOk04u7Nvl5L8T5nM8uXxMsVpWqu5mxm1raUaUFQUi9Jj0iaK2mOpDOy/q6SpkhakP3skvVL0jWSaiTNkrRPwbmGZuMXSBpaysdwcDazXCnjVro64KyI+DxwAHCapL7AecDUiOhD4+aINQsEhwN9slYN3ACNwRy4CNifxvW7i9YE9GIcnM0sX8qUOUfE4oh4Jnv9HjCXxo0Rg4Ex2bAxwFHZ68HAbdHoCWAbST2Aw4ApEbEsIpYDU4BBzX0MB2czy5eNCM6FN8xlrbqpU0rqDewNPAl0j4jF0BjAgTX7IHsCiwreVpv1bai/KC8Imlm+bMRt2RExChhVbIykzsC9wJkR8a60wQ0eTR2IIv1FOXM2s1yJhii5NUfSFjQG5jsiYnzWvSQrV5D9XJr11wK9Ct6+E40PittQf1EOzmaWL+XbrSHgZmBuRFxZcGgisGbHxVDgvoL+k7JdGwcA72Rlj4eAgZK6ZAuBA7O+olzWMLN8Kd8DjQ4ETgSel/Rc1ncBcDkwVtIw4DXgW9mxB4AjgBpgJXAyQEQsk3QJjU/1BBgREcuau7iDs5nlS5lu346Iv9J0vRjgkCbGB3DaBs41Ghi9Mdd3cDazfMnJszUcnM0sV6I+H7dvOzibWb44czYzS08pW+TaAgdnM8sXB2czswTlo+Ts4Gxm+RJ1+YjODs5mli/5iM0OzmaWL14QNDNLkTNnM7P0OHM2M0uRM2czs/REXaVnUB4OzmaWK+HM2cwsQQ7OZmbpceZsZpYgB2czswRF/Qa/HbtNcXA2s1xx5mxmlqBocOZsZpYcZ85mZgmKcOZsZpYcZ85mZglq8G4NM7P0eEHQzCxBDs5mZgmKfDzO2cHZzPLFmbOZWYK8lc7MLEH1OdmtUVXpCZiZlVOESm7NkTRa0lJJswv6fibpdUnPZe2IgmPnS6qRNE/SYQX9g7K+GknnlfI5HJzNLFeiQSW3EtwKDGqi/6qI2CtrDwBI6gsMAfbI3nO9pHaS2gHXAYcDfYHjs7FFuaxhZrlSzt0aETFNUu8Shw8G7o6Ij4CXJdUA+2XHaiJiIYCku7OxLxQ7mTNnM8uVjcmcJVVLmlnQqku8zHBJs7KyR5esryewqGBMbda3of6iHJzNLFfqG6pKbhExKiL6FbRRJVziBmA3YC9gMTAy62+qThJF+otyWcPMcqWlb0KJiCVrXku6Ebg/+7UW6FUwdCfgjez1hvo3yJmzmeVKQ6jktikk9Sj49WhgzU6OicAQSR0l7QL0AZ4CZgB9JO0iqQONi4YTm7uOM2czy5Vy3oQi6S5gANBNUi1wETBA0l40liZeAU5tvG7MkTSWxoW+OuC0iKjPzjMceAhoB4yOiDnNXjta+P8DrH5rYU7udLdy2nLH/pWegiWobtXrmx1Zn+k1uOSYs8+i+5K9Y6XFM+fdPju4pS9hbdAOnbs0P8hsE2xquSI1LmuYWa7UN+RjKc3B2cxyJS91VAdnM8sVlzXMzBLkR4aamSUoJ1++7eBsZvkSTd4t3fY4OJtZrtS5rGFmlh5nzmZmCXLN2cwsQc6czcwS5MzZzCxB9c6czczSU9r3tqbPwdnMcqXBmbOZWXr84CMzswR5QdDMLEENclnDzCw59ZWeQJk4OJtZrni3hplZgrxbw8wsQd6tYWaWIJc1zMwS5K10ZmYJqnfmbGaWHmfOZmYJcnA2M0tQTr5C0MHZzPLFmbOZWYLycvt2VaUnYGZWTg0qvTVH0mhJSyXNLujrKmmKpAXZzy5ZvyRdI6lG0ixJ+xS8Z2g2foGkoaV8DgdnM8uVho1oJbgVGLRO33nA1IjoA0zNfgc4HOiTtWrgBmgM5sBFwP7AfsBFawJ6MQ7OZpYr5QzOETENWLZO92BgTPZ6DHBUQf9t0egJYBtJPYDDgCkRsSwilgNTWD/gr8fB2cxyJTaiSaqWNLOgVZdwie4RsRgg+7l91t8TWFQwrjbr21B/UV4QNLNc2Zhna0TEKGBUmS7d1JWjSH9RzpzNLFfqN6JtoiVZuYLs59KsvxboVTBuJ+CNIv1FOTibWa40ECW3TTQRWLPjYihwX0H/SdmujQOAd7Kyx0PAQEldsoXAgVlfUS5rmFmulPMmFEl3AQOAbpJqadx1cTkwVtIw4DXgW9nwB4AjgBpgJXAyQEQsk3QJMCMbNyIi1l1kXI+Ds5nlSjkfth8Rx2/g0CFNjA3gtA2cZzQwemOu7eBsZrni27fNzBJUp3x8UZWDs5nlSj5Cs4OzmeWMyxpmZgnajC1ySXFwNrNcyUdodnA2s5xxWcPMLEH1OcmdHZzNLFecOZuZJSicOZuZpScvmbOfSlcmPXp25+77bmbqE/fx8PQJnHLqt//X8erhQ3lt2fN06boNAAcc2I/Zr0znwcfu4cHH7uGMs79fiWlbC+vRcwfG3jeaR56YyNTpf2TYqf8BwI8vGM6Ux8fz0GPjuOPeUXTfYTsAtt66M7fceS1/nnYvU6f/keNOOKrY6a0JrfBUulbhzLlM6uvqufQnVzB71lw6dd6KSX/5A48/+ncWzFtIj57d6T/gy9Qu+t+PcJ3x92c4+fjhFZqxtYb6ujpG/OTXa/8uHvzLWKY9Op3/+u0tXPHzawE4pfrbnHn2Dzj/rBEM/e7xLJj3EiefMJyu23Zh2lP3M+Ge+1m9uq7Cn6TtSDvkls6Zc5ksXfIWs2fNBWDF+yupmf8yO/ToDsBFl53Dzy+6ksaHVtnHybp/FwvmL2SHHt15/70Va8dsudWWa/82IoJOnTsB0KnTVvxr+TvU1W3GY+E/huqIklvKnDm3gJ167cgeX/wczz49i68PGsA/Fy9l7pz5643bZ98vMXnaOJb8800u++kVzH/xpQrM1lrLTr12ZM8vfp5nn54FwDkXns6xQ47k3Xff47gjTwHg1pvu5JY7ruXpFx6hc+dO/GDYj/2P+kbKy4LgJmfOkk4ucmztlya+/1Gzz5TOla06bcnvxlzFxRf8krq6eoaf9T1G/vy69cbNnjWXL39pIIO+eiy3jrqTG2//TQVma61lq05bMmrMVfzsgl+uzZp/ddk17PeFQ5lwzyRO/t4JAAw4+EDmzH6R/9P3IA772jFc+qsL6Lx1p0pOvc0p57dvV9LmlDUu3tCBiBgVEf0iol/njl034xJtS/v27fndmKuYMG4Sk++fys69e9Hr0z2Z/Pg4/vbcZHrs2J0HHh3Ldttvy/vvrWDlig8AeOThx2m/Rfu1i4WWL+3bt2fUmKuZMG4SD97/8HrH/zhuEof/30MBOO6Eo3nwT41jXnl5EYtefZ3P9NmlVefb1sVG/C9lRcsakmZt6BDQvfzTadt+fc3F1MxfyE3X3wbAvLkL2Gf3AWuP/+25yfz7wUNYvuxfbLf9try59G0AvrTPnlRVVbF82b8qMW1rYVdcM4Ka+Qu5Mfu7ANhl10/z8sLXABh4+EG8tOBlAF6vXcxXvnYATz3xDN2225bdPtObV1+prci826rUM+JSNVdz7g4cBixfp1/A9BaZURu17/57c8yQI5k7Zz4PPnYPAL+65BoeefjxJscfceRATjzlOOrq6vnwww8Z/t2zW3O61kr23X9vjs3+Lh56bBwAv7zkNww58Zvs+pneRENQu+gNzj9rBAC/ueK/uPK6y3j4r+NB4ucXX+V/tDdSfU5q9Cq22CDpZuCWiPhrE8fujIgTmrvAp7t+IR//paysUt9japVRu2y2NvccJ+x8dMl/XHe+OmGzr9dSimbOETGsyLFmA7OZWWtLvZZcKm+lM7Nc+bjUnM3M2pS8lMwcnM0sV1zWMDNLUF52azg4m1muuKxhZpYgLwiamSXINWczswS5rGFmlqC8PGLVD9s3s1ypJ0puzZH0iqTnJT0naWbW11XSFEkLsp9dsn5JukZSjaRZkvbZnM/h4GxmudIC3yF4UETsFRH9st/PA6ZGRB9gavY7wOFAn6xVAzdszudwcDazXImIktsmGgyMyV6PAY4q6L8tGj0BbCOpx6ZexMHZzHJlYzLnwm9tylr1OqcL4M+Sni441j0iFgNkP7fP+nsCiwreW5v1bRIvCJpZrmzMVrqIGAWMKjLkwIh4Q9L2wBRJLxYZ29TjRzc5PXdwNrNcKeft2xHxRvZzqaQJwH7AEkk9ImJxVrZYmg2vBXoVvH0n4I1NvbbLGmaWK+VaEJTUSdLWa14DA4HZwERgaDZsKHBf9noicFK2a+MA4J015Y9N4czZzHKljDehdAcmSILGWHlnREyWNAMYK2kY8BrwrWz8A8ARQA2wEjh5cy7u4GxmuVKum1AiYiHwpSb63wYOaaI/gNPKcnEcnM0sZ3z7tplZgvzgIzOzBNVHPh4a6uBsZrmSlwcfOTibWa645mxmliDXnM3MEtTgsoaZWXqcOZuZJci7NczMEuSyhplZglzWMDNLkDNnM7MEOXM2M0tQfdRXegpl4eBsZrni27fNzBLk27fNzBLkzNnMLEHerWFmliDv1jAzS5Bv3zYzS5BrzmZmCXLN2cwsQc6czcwS5H3OZmYJcuZsZpYg79YwM0uQFwTNzBLksoaZWYJ8h6CZWYKcOZuZJSgvNWfl5V+ZtkBSdUSMqvQ8LC3+u7CmVFV6Ah8z1ZWegCXJfxe2HgdnM7MEOTibmSXIwbl1ua5oTfHfha3HC4JmZgly5mxmliAHZzOzBDk4txJJgyTNk1Qj6bxKz8cqT9JoSUslza70XCw9Ds6tQFI74DrgcKAvcLykvpWdlSXgVmBQpSdhaXJwbh37ATURsTAiVgF3A4MrPCersIiYBiyr9DwsTQ7OraMnsKjg99qsz8ysSQ7OrUNN9HkPo5ltkINz66gFehX8vhPwRoXmYmZtgINz65gB9JG0i6QOwBBgYoXnZGYJc3BuBRFRBwwHHgLmAmMjYk5lZ2WVJuku4O/A7pJqJQ2r9JwsHb5928wsQc6czcwS5OBsZpYgB2czswQ5OJuZJcjB2cwsQQ7OZmYJcnA2M0vQfwO/sGrhaLg22AAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEICAYAAACDGjUCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAF2hJREFUeJzt3X2UVNWZ7/HvD8TEICqIIDQoEpFonBl1OcYbw4pGRdBEoo4ziFFCiM1kRNQ4I6i58SVqnHtFoxP1BhXFFyCMLxGVhCA6JMaoqGEQggjiCy0ENBgTkRvp6uf+0QduCd3VBVR37T7+Pq69qmqfXefsWhYPD8/Z55QiAjMzS0uHak/AzMy25uBsZpYgB2czswQ5OJuZJcjB2cwsQQ7OZmYJcnA2M0uQg7NVjKQvSXpG0vuS1kn6jaRBktZL6tLE+N9JGiupn6SQ9NIW27tL+kjSG232IcwS4eBsFSFpN+Ax4D+AbkANcCXwPlAHnLbF+IOBg4BpRd2ds/5NRgCvt+K0zZLl4GyVcgBAREyLiEJEbIiIX0bEQmAKcPYW488GHo+IPxb13QuM3GLMPa05abNUOThbpbwKFCRNkTRUUteibfcCgyTtAyCpA41Z8ZaB9z5guKSOkg4EugDPtcHczZLj4GwVERF/Br4EBHA78I6kmZJ6RsRKYB7wjWz4scCngce32E0dsBQ4jsYM2lmzfWI5OFvFRMSSiPhmRPQBDgZ6Az/KNheXNs4CpkbExiZ2cw/wTeAMGjNps08kB2drFRHxCnA3jUEa4CGgRtIxwKk0nxU/CJwErIiIN1t7nmap2qnaE7B8kPQ5GoPqTyOiTlJfGrPfZwEiYr2kB4C7gDcj4oWm9pON+wrwXhtN3SxJzpytUv4CfAF4TtJ6GoPyIuCiojFTgH1poZYcES9ExGutNVGz9kC+2b6ZWXqcOZuZJcjB2cwsQQ7OZmYJcnA2M0tQqy+l2/juCp9xtK3s0ntQtadgCar/6G3t6D62JeZ06t5/h4/XWpw5m5klyBehmFm+NBSqPYOKcHA2s3wp1Fd7BhXh4GxmuRLRUO0pVISDs5nlS4ODs5lZepw5m5klyCcEzcwS5MzZzCw94dUaZmYJ8glBM7MEuaxhZpYgnxA0M0uQM2czswT5hKCZWYJ8QtDMLD0RrjmbmaXHNWczswS5rGFmliBnzmZmCSpsrPYMKsLB2czyJSdlDf/Aq5nlSzSU30qQ1FfSU5KWSFos6fys/wpJb0takLUTi95ziaTlkpZKOqGof0jWt1zShHI+hjNnM8uXymXO9cBFEfGSpC7Ai5LmZNtujIjriwdLOggYDnwe6A08IemAbPMtwPFAHTBf0syI+H2pgzs4m1m+VCg4R8RqYHX2/C+SlgA1Jd4yDJgeEX8FXpe0HDgi27Y8IlYASJqejS0ZnF3WMLNcicLGspukWkkvFLXapvYpqR9wKPBc1jVW0kJJkyV1zfpqgJVFb6vL+prrL8nB2czyZRtqzhExKSIOL2qTttydpF2BB4ELIuLPwG3AZ4FDaMysJ24a2tRsSvSX5LKGmeVLBVdrSOpEY2C+PyIeAoiINUXbbwcey17WAX2L3t4HWJU9b66/Wc6czSxfKrdaQ8CdwJKIuKGov1fRsFOARdnzmcBwSZ+StB8wAHgemA8MkLSfpJ1pPGk4s6WP4czZzPKlcpnzUcBZwMuSFmR9lwJnSDqExtLEG8AYgIhYLGkGjSf66oFzI7sLk6SxwGygIzA5Iha3dHAHZzPLlwpdvh0RT9N0vXhWifdcA1zTRP+sUu9rioOzmeVLvW+2b2aWHt/4yMwsQTm5t4aDs5nlizNnM7MEOXM2M0uQM2czswR5tYaZWYKixdtWtAsOzmaWL645m5klyMHZzCxBPiFoZpagQqHaM6gIB2czyxeXNczMEuTgbGaWINeczczSEw1e52xmlh6XNczMEuTVGmZmCXLmbGaWoJwE5w7VnkB7tnrNO4waO56vjahl2JljuHfGzwB45dXXGHHOBZw28lz+8VvjePn3SwFY8eZKzqy9kEOP/hp3TX3gY/t6+tkX+OrwbzP0H7/FHffOaPPPYm2nQ4cOzH9+No88PAWAfv368szTj7Jk8dNMvf82OnXqVOUZtnMR5beEOTjvgJ06duTfzjuHR6dOYuqkG5n+0GO89vqbTLz1Tr7zrTN5cMotjP32N5h4650A7L5bFyZc+M9884zTPrafQqHA1RNv4baJP2Dm/T9h1hP/xWuvv1mNj2RtYNx53+aVV5Ztfv3Day/jRzffzoGf/xLvvfc+3xp1RhVnlwMNDeW3hLUYnCV9TtJ4STdLuil7fmBbTC51e3XvxkED9wegc+fP0H/fvqx5549I4oP1HwLwwfoP6dF9TwD27LoHf3PgQHba6ePVpJeXvMo+fXrTt6YXnTp1YuixX+bJXz/bth/G2kRNTS9OHHoskydP29x3zNFH8eCDjwNw773/ybCTT6jW9PKhIcpvCStZc5Y0HjgDmA48n3X3AaZJmh4R17Xy/NqNt1evYcmy1/jbzw9k/PljGPPd73H9LXcQDcF9P5lY8r1r33mXvXvstfl1zx7deXnx0taeslXBDROvZMIlV9Oly64A7LlnV/70p/cpZCsM6t5eTe+avas5xfYvJ6s1WsqcRwN/HxHXRcR9WbsOOCLb1iRJtZJekPTCHfdMa25Ybnz44QYuvOxqxo8bw66dO/PThx9n/Hm1zH34Xi4eV8v3f/ijku9vqvQltdJkrWpOOvE41q59l5d+9/LmPjXxPzoSr4WmLhoaym4pa2m1RgPQG9iyANor29akiJgETALY+O6KXH/TNtbXc8FlV3PS4GM4/uijAJj58ye45IJ/BuCErwzi8utKB+eePbrzh7XvbH69Zu277JWVQiw/vvjFw/naVwczdMhX+PSnP8Vuu3XhholXssceu9OxY0cKhQJ9anqxetWaak+1fUu8XFGuljLnC4C5kn4uaVLWfgHMBc5v/emlLSL4/g9/RP99+zJy+Kmb+/fqvifzs+zouRcXsG/fmpL7OfhzB/BW3SrqVv2BjRs38vO58zjmS0e26tyt7V32vevo1/9w9j/gSM78xr/w1FO/4eyR5/Ff857htNNOAuCss05n5qO/rPJM27loKL8lrGTmHBG/kHQAjWWMGkBAHTA/IvJR2NkBv1u4mEd/MZcBn+3HaSPPBeD8MSO5cvw4rrvpJ9QXCnxq5525/OJxALz7x3X80+hxfLD+Qzp06MB9M37GI/f/hF07d+bSC7/DmO9+j0KhwClfHcz+/fet5kezNnTJpdcw9b5bueqKi1nw34uZfFf+S4GtKieZs1q7vpX3soZtn116D6r2FCxB9R+9vcNnW9Z/f3jZMafzVdOTPbvjKwTNLF8SL1eUyxehmFm+VGids6S+kp6StETSYknnZ/3dJM2RtCx77Jr1K7seZLmkhZIOK9rXyGz8Mkkjy/kYDs5mlisVXEpXD1wUEQcCRwLnSjoImADMjYgBNC6OmJCNHwoMyFotcBs0BnPgcuALNJ6/u3xTQC/FwdnM8qVCmXNErI6Il7LnfwGW0LgwYhgwJRs2Bfh69nwYcE80ehbYQ1Iv4ARgTkSsi4j3gDnAkJY+hoOzmeXLNgTn4gvmslbb1C4l9QMOBZ4DekbEamgM4ECPbFgNsLLobXVZX3P9JfmEoJnlyzZcvl18wVxzJO0KPAhcEBF/buqqzk1DmzpEif6SnDmbWa5EQ5TdWiKpE42B+f6IeCjrXpOVK8ge12b9dUDforf3AVaV6C/JwdnM8qVyqzUE3AksiYgbijbNBDatuBgJPFLUf3a2auNI4P2s7DEbGCypa3YicHDWV5LLGmaWL5W7odFRwFnAy5IWZH2XAtcBMySNBt4CTs+2zQJOBJYDHwKjACJinaQfAPOzcVdFxLqWDu7gbGb5UqHLtyPiaZquFwMc28T4AM5tZl+TgcnbcnwHZzPLl5zcW8PB2cxyJQr5uHzbwdnM8sWZs5lZespZItceODibWb44OJuZJSgfJWcHZzPLl6jPR3R2cDazfMlHbHZwNrN88QlBM7MUOXM2M0uPM2czsxQ5czYzS0/UV3sGleHgbGa5Es6czcwS5OBsZpYeZ85mZglycDYzS1AUmv117HbFwdnMcsWZs5lZgqLBmbOZWXKcOZuZJSjCmbOZWXKcOZuZJajBqzXMzNLjE4JmZglycDYzS1Dk43bODs5mli/OnM3MEuSldGZmCSrkZLVGh2pPwMyskiJUdmuJpMmS1kpaVNR3haS3JS3I2olF2y6RtFzSUkknFPUPyfqWS5pQzudwcDazXIkGld3KcDcwpIn+GyPikKzNApB0EDAc+Hz2nlsldZTUEbgFGAocBJyRjS3JZQ0zy5VKrtaIiF9J6lfm8GHA9Ij4K/C6pOXAEdm25RGxAkDS9Gzs70vtzJmzmeXKtmTOkmolvVDUass8zFhJC7OyR9esrwZYWTSmLutrrr8kB2czy5VCQ4eyW0RMiojDi9qkMg5xG/BZ4BBgNTAx62+qThIl+ktyWcPMcqW1L0KJiDWbnku6HXgse1kH9C0a2gdYlT1vrr9ZzpzNLFcaQmW37SGpV9HLU4BNKzlmAsMlfUrSfsAA4HlgPjBA0n6SdqbxpOHMlo7jzNnMcqWSF6FImgYcDXSXVAdcDhwt6RAaSxNvAGMajxuLJc2g8URfPXBuRBSy/YwFZgMdgckRsbjFY0cr/xtg47srcnKlu1XSLr0HVXsKlqD6j97e4cj6Ut9hZcecw1Y+kuwVK62eOe93wMmtfQhrh/betWvLg8y2w/aWK1LjsoaZ5UqhIR+n0hyczSxX8lJHdXA2s1xxWcPMLEG+ZaiZWYJy8uPbDs5mli/R5NXS7Y+Ds5nlSr3LGmZm6XHmbGaWINeczcwS5MzZzCxBzpzNzBJUcOZsZpae8n63NX0OzmaWKw3OnM3M0uMbH5mZJcgnBM3MEtQglzXMzJJTqPYEKsTB2cxyxas1zMwS5NUaZmYJ8moNM7MEuaxhZpYgL6UzM0tQwZmzmVl6nDmbmSXIwdnMLEE5+QlBB2czyxdnzmZmCcrL5dsdqj0BM7NKalD5rSWSJktaK2lRUV83SXMkLcseu2b9knSzpOWSFko6rOg9I7PxyySNLOdzODibWa40bEMrw93AkC36JgBzI2IAMDd7DTAUGJC1WuA2aAzmwOXAF4AjgMs3BfRSHJzNLFcqGZwj4lfAui26hwFTsudTgK8X9d8TjZ4F9pDUCzgBmBMR6yLiPWAOWwf8rTg4m1muxDY0SbWSXihqtWUcomdErAbIHntk/TXAyqJxdVlfc/0l+YSgmeXKttxbIyImAZMqdOimjhwl+kty5mxmuVLYhrad1mTlCrLHtVl/HdC3aFwfYFWJ/pIcnM0sVxqIstt2mglsWnExEnikqP/sbNXGkcD7WdljNjBYUtfsRODgrK8klzXMLFcqeRGKpGnA0UB3SXU0rrq4DpghaTTwFnB6NnwWcCKwHPgQGAUQEesk/QCYn427KiK2PMm4FQdnM8uVSt5sPyLOaGbTsU2MDeDcZvYzGZi8Lcd2cDazXPHl22ZmCapXPn6oysHZzHIlH6HZwdnMcsZlDTOzBO3AErmkODibWa7kIzQ7OJtZzrisYWaWoEJOcmcHZzPLFWfOZmYJCmfOZmbpyUvm7LvSVUivmr2Z8chknnp2JnOf+Rmjx3zjY9vHjP0mdesW0bXbHh/r/7tDD+bNd/6bk04+vi2na22kue/Fv146ljm/fojZ8x7g/gcn0XPvvQDYfffduOOem5jz64d4bM40Bh64fzWn3y61wV3p2oSDc4UU6uu56n/+b4458mROHjyCkaOHM2Bgf6DxD+igo/8HdSs/fgvXDh06cOnlFzLvyd9UY8rWBpr7Xvyf/7iL4wedyglf/gfmzp7HBf/2HQDO++45LF70CscPOpXz/+VSrrx2QgtHsC1tyy+hpMzBuULWrnmXRQuXALD+gw9Z9uoK9u7VE4ArrrmYay6/gcabVv1/o2pHMOvRObz7Tot3D7R2qrnvxQd/Wb95zC6f2WXzd2PAwM/y9LxnAXht2ev02aeG7nvt2fYTb8fqibJbyhycW0Gfvr05+G8P5HcvLuT4IUfzh9VrWbJ46cfG7N2rB0NPOpZ775pRpVlaWyv+XgBcfNk4nn/5CU45/SSu/+GPAfj9oqUM/dpxABxy2MH06duLXr17Vm3O7VFsw38p2+7gLGlUiW2bfzRx/V8/WVnhZzrvwqQpN3LFpf9OfX2BcRfVcv21P95q3BXXjufaK2+koSEvpy+slOLvxaas+X9dczNH/M1xPPyfjzPqnBEA3HLTHey+x27MnvcAo845k0ULX6G+fgd+UOkTqJK/vl1N2vKf2mW/UXorIvZpaVyfbgen/ddTBe20007cPf0W5j35G26/9R4+d+AApv/sDjZs+L8A9OrdkzV/eIevHjecR2bfj9T4u4/dunVlw4YNjL/wSmbPerKaH8FawZbfiy3V9OnFlJ/eynFHnbLVtt8umM3xg079WBkkz+rWLdqGn2dt2qh+p5Udc+5648EdPl5rKbmUTtLC5jYB/rfWFq6/+SqWv7pi8x/AV5Ys45CBX968/bcLZnPiV/6J99b9iS8eOmRz/w0/vpq5v5znwJxTW34vAPbrvw+vr3gLgMFDj+G1Za8DsNtuXdiwYQMbN9Yz4uzTeO6ZFz8xgblSUs+Iy9XSOueewAnAe1v0C3imVWbUTv39Fw7lH4afzJLFrzJ73gMA/PsPbuLJJ35d5ZlZNTX3vRh+1qn0378f0RDUrVzFJRddBcD+A/tz063XUigUWLZ0Bf867vvVnH67VNjOakBqSpY1JN0J3BURTzexbWpEjGjpAJ+ksoaZ7ZhKlDVG7HtK2TFn6psPt8+yRkSMLrGtxcBsZtbWUl+FUS5fvm1mufJJqTmbmbUrqV+WXS4HZzPLFZc1zMwSlJfVGg7OZpYrLmuYmSXIJwTNzBLkmrOZWYJc1jAzS9D23swtNQ7OZpYrhZxkzr7ZvpnlSiV/Q1DSG5JelrRA0gtZXzdJcyQtyx67Zv2SdLOk5ZIWSjpsRz6Hg7OZ5UpElN3KdExEHBIRh2evJwBzI2IAMDd7DTAUGJC1WuC2HfkcDs5mlitt8Ovbw4Ap2fMpwNeL+u+JRs8Ce0jqtb0HcXA2s1zZlt8QLP5JvazVbrU7+KWkF4u29YyI1QDZY4+svwZYWfTeuqxvu/iEoJnlyrZcvh0Rk4BJJYYcFRGrJPUA5kh6pcTYpu4Nvd3puTNnM8uVSpY1ImJV9rgWeBg4AlizqVyRPa7NhtcBfYve3gdYtb2fw8HZzHKlUsFZUmdJXTY9BwYDi4CZwMhs2Ejgkez5TODsbNXGkcD7m8of28NlDTPLlQpehNITeFgSNMbKqRHxC0nzgRmSRgNvAadn42cBJwLLgQ+BUTtycAdnM8uVSl2+HRErgL9rov+PwLFN9AdwbkUOjoOzmeWMb3xkZpagQuTjpqEOzmaWK77xkZlZgnzLUDOzBLnmbGaWoAaXNczM0uPM2cwsQV6tYWaWIJc1zMwS5LKGmVmCnDmbmSXImbOZWYIKUaj2FCrCwdnMcsWXb5uZJciXb5uZJciZs5lZgrxaw8wsQV6tYWaWIF++bWaWINeczcwS5JqzmVmCnDmbmSXI65zNzBLkzNnMLEFerWFmliCfEDQzS5DLGmZmCfIVgmZmCXLmbGaWoLzUnJWXv2XaA0m1ETGp2vOwtPh7YU3pUO0JfMLUVnsCliR/L2wrDs5mZglycDYzS5CDc9tyXdGa4u+FbcUnBM3MEuTM2cwsQQ7OZmYJcnBuI5KGSFoqabmkCdWej1WfpMmS1kpaVO25WHocnNuApI7ALcBQ4CDgDEkHVXdWloC7gSHVnoSlycG5bRwBLI+IFRHxETAdGFblOVmVRcSvgHXVnoelycG5bdQAK4te12V9ZmZNcnBuG2qiz2sYzaxZDs5tow7oW/S6D7CqSnMxs3bAwbltzAcGSNpP0s7AcGBmledkZglzcG4DEVEPjAVmA0uAGRGxuLqzsmqTNA34LTBQUp2k0dWek6XDl2+bmSXImbOZWYIcnM3MEuTgbGaWIAdnM7MEOTibmSXIwdnMLEEOzmZmCfp/n/92X43Fb0sAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 2 Axes>"
       ]
@@ -1638,12 +1669,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEICAYAAACDGjUCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAGlFJREFUeJzt3Xu4VVW9//H3Z28uEpigIHFLzYManrwiamaRF/CSYVkeLymZhXW8Zhe1UtM07TlppqXnkJJ6vCC/FAVTidC8pkJGKiK5wws3QcW8ACJ7r+/5Y034rWCz9tqw9l5jTz8vnvHstcYcc86xeHi++8t3jjmXIgIzM0tLXa0nYGZm63JwNjNLkIOzmVmCHJzNzBLk4GxmliAHZzOzBDk4W6tIGi5pfq3nYZZ3Ds45IOklSSskvSvpVUnXS+pR63ltLEkhaVn2ud6V9M92Pr9/EVnNODjnx2ER0QPYBdgVOKfG86mWnSOiR9Z6tnZnSZ3aYlJmbc3BOWci4lVgCsUgDYCkQyX9VdLbkuZJ+nHJtq2zDHW0pFckvS7phyXbu2WZ+JuSngP2KD2fpI9L+pOkf0qaJenzJduul3S1pHuzzPdRSR+RdEV2vOcl7bohn1PSNyQ1SFoqaZKk/iXbQtLJkl4AXsj6dpA0NRs/R9KRJeMPkfScpHckLZD0XUndgXuB/iWZe/91JmLWRhycc0bSQOBgoKGkexlwPNATOBT4lqTD19r1U8D2wP7AeZI+nvWfD2ybtZHA6JJzdQYmA38AtgROBW6WtH3JcY8EfgT0BlYCfwaeyt7/Drh8Az7jfsAl2bH7AS8D49cadjiwJzAkC7RTgVuyeR4NXC1px2zsdcBJEbEp8O/A/RGxjOLf48KSzH1ha+dqtqEcnPPjTknvAPOAJRSDKgAR8aeIeCYiChHxNHAr8Jm19r8gIlZExN+AvwE7Z/1HAhdHxNKImAdcWbLPXkAP4NKIeD8i7gfuphj8VpsYEX+JiPeAicB7EXFjRDQBt1EswZTzVJaV/1PS6nMfC4yLiKciYiXFEs7ekrYu2e+SbM4rgM8BL0XEbyOiMSKeAm4HvpSNXUUxiH84It7MtpvVlINzfhyeZX7DgR0oZqYASNpT0gOSXpP0FvDN0u2ZV0teL6cYdAH6Uwz4q71c8ro/MC8iCmttH1DyfnHJ6xXNvG/pwuVuEdEza6eVnHfNPCLiXeCNtc5bOuetgD1Lgvw/KQb4j2TbjwAOAV6W9KCkvVuYk1mbc3DOmYh4ELge+HlJ9y3AJGBQRGwG/DegCg+5CBhU8v6jJa8XAoMk1a21fUErp91aCykGXACyssUWa5239HGL84AHS4J8z6xM8S2AiJgeEaMoljzuBCY0cwyzduXgnE9XAAdKWn1RcFNgaUS8J2kYcEwrjjUBOEdSr6yefWrJtico1rO/L6mzpOHAYaxb/622W4ATJO0iqSvwU+CJiHhpPePvBraTdFw2z86S9sguZnaRdKykzSJiFfA20JTttxjYQtJmbfx5zNbh4JxDEfEacCNwbtb1n8CFWU36PP5/ZliJCyiWEF6keOHvf0vO8z7weYoXzl4HrgaOj4jnN/YzlBMR0yh+ttspZvbbAkeVGf8OMCIbs5BiCednQNdsyHHAS5Lepljy+Uq23/MU6/Nzs3KIV2tYu5Eftm9mlh5nzmZmCXJwNjNLkIOzmVmCHJzNzBLU5g+FWfX6XF9xtHV0679vradgCWp8f0Gl6+/XqzUxp3Pvj230+dqKM2czswT5cYpmli+FppbHdAAOzmaWL02NtZ5BVTg4m1mu/OtzuDouB2czy5eCg7OZWXqcOZuZJcgXBM3MEuTM2cwsPeHVGmZmCfIFQTOzBLmsYWaWIF8QNDNLkDNnM7ME+YKgmVmCfEHQzCw9Ea45m5mlxzVnM7MEuaxhZpYgZ85mZglqWlXrGVSFg7OZ5UtOyhr+glczy5coVN7KkDRI0gOSZkuaJen0rP/HkhZImpm1Q0r2OUdSg6Q5kkaW9B+U9TVIOruSj+HM2czypXqZcyPwnYh4StKmwF8kTc22/SIifl46WNIQ4ChgR6A/8EdJ22Wbfw0cCMwHpkuaFBHPlTu5g7OZ5UuVgnNELAIWZa/fkTQbGFBml1HA+IhYCbwoqQEYlm1riIi5AJLGZ2PLBmeXNcwsV6JpVcVN0hhJM0ramOaOKWlrYFfgiazrFElPSxonqVfWNwCYV7Lb/Kxvff1lOTibWb60ouYcEWMjYmhJG7v24ST1AG4HzoiIt4FrgG2BXShm1petHtrcbMr0l+WyhpnlSxVXa0jqTDEw3xwRdwBExOKS7b8B7s7ezgcGlew+EFiYvV5f/3o5czazfKneag0B1wGzI+Lykv5+JcO+ADybvZ4EHCWpq6RtgMHAk8B0YLCkbSR1oXjRcFJLH8OZs5nlS/Uy532A44BnJM3M+n4AHC1pF4qliZeAkwAiYpakCRQv9DUCJ0f2FCZJpwBTgHpgXETMaunkDs5mli9Vun07Ih6h+XrxPWX2uRi4uJn+e8rt1xwHZzPLl0Y/bN/MLD1+8JGZWYJy8mwNB2czyxdnzmZmCXLmbGaWIGfOZmYJ8moNM7MERYuPregQHJzNLF9cczYzS5CDs5lZgnxB0MwsQU1NtZ5BVTg4m1m+uKxhZpYgB2czswS55mxmlp4oeJ2zmVl6XNYwM0uQV2uYmSXImbOZWYIcnG3R4tf4wU9+zutL36RO4kujDua4Iw/n+b//gwv/6ypWvr+K+vp6zv3uyXxiyPbMfXke5158Oc/9vYHTxozmhGO+tOZYN46fyO2T70MSg7fdmot+cCZdu3ap4aezttC1a1f+dP/tdOnalU6d6rnjjt9zwYWXceMNV7H77juzatUqpk+fybf+8ywac/J0tXaXkwcf1dV6Ah1Zp/p6vnfqN5h8y1huGfsLxt9xN/948WUuu/o6vvW1Y7n9hl9zyte/wmVXXwfAZh/elLO//U2+evQR/3Kcxa+9zs2/u4vbxl3JnTf9N4VCgXv/+GAtPpK1sZUrV3LAiCPZfeiB7D50BCNHDGfPYbtx660T2fHfP80uu+5Pt26bcOLXjqn1VDuuQqHylrAWM2dJOwCjgAFAAAuBSRExu43nlrw+vTenT+/NAeje/UN8bKtBLH7tDSTx7rLlALy7bDlb9t4CgC169WSLXj156LHp6xyrsamJlSvfp1N9J1a8t3LNcS1/lmX/Njp37kSnzp2JCO697/4126dPn8nAgf1qNb2OLydL6cpmzpLOAsYDAp4Epmevb5V0dttPr+NYsGgxs1/4BzvtuD1nnX4Sl119Hft/4Th+/qtrOeObXy27b98+vfnq0UdwwBeP57OjjmHT7h9inz13b5+JW7urq6tjxvQ/sGjB00yb9hBPTv/rmm2dOnXi2GOPYMqUB2o4ww6uqanylrCWyhonAntExKURcVPWLgWGZduaJWmMpBmSZlx7463VnG+Sli9fwbd/eBFnnXYSPbp357aJv+esU8cwbeL/8v3TxnDeJVeU3f+tt9/hgYcfZ8r/+y3333UzK95byeQp95fdxzquQqHA0D1GsNU2Q9lj6K7suOP2a7b96qqf8vDDT/DIo0/WcIYdWxQKFbeUtRScC0D/Zvr7ZduaFRFjI2JoRAz9+vFHb8z8kreqsZEzfngRh474LAcO3weASff+kQOy1yP325dnnptT9hiPz5jJgP592bxXTzp36sT+n/kkM595rs3nbrX11ltv8+BDjzFyxHAAzv3Rt+nTZwu++70f13ReHV4hKm8Jayk4nwFMk3SvpLFZuw+YBpze9tNLW0Rw3iVX8LGtBjH6qC+u6e/Tewum//UZAJ74y0y2GjSg7HH69e3D088+z4r33iMieGLGTD621aA2nbvVRu/em7PZZh8GYJNNNmH//fZlzpx/8LUTjmbEgcM59isnEzlZbVAzUai8JazsBcGIuE/SdhTLGAMo1pvnA9MjIu2CTTv469OzmHzfNAZvuzVHjD4ZgNNPGs0FZ53Gpb/8HxqbmujapQvnf/80AF5/Yyn/ceJpvLtsOXV1ddw04U7uuvl/2GnHHTjws5/iyBNOpb6+nh2225Yvjzq4lh/N2ki/fn0Zd90V1NfXUVdXx+9+N5nf3/NH3lv+Mi+/PJ9HHp4EwJ133sNFF5cvh9l6JJ4RV0pt/Vt61etz8/E3ZVXVrf++tZ6CJajx/QXa2GMsO++oimNO9wvHb/T52opvQjGzfEm8XFEp34RiZvlSpQuCkgZJekDSbEmzJJ2e9W8uaaqkF7KfvbJ+SbpSUoOkpyXtVnKs0dn4FySNruRjODibWa5UcSldI/CdiPg4sBdwsqQhwNnAtIgYTHFxxOp7Pg4GBmdtDHANFIM5cD6wJ8Xrd+evDujlODibWb5UKXOOiEUR8VT2+h1gNsWFEaOAG7JhNwCHZ69HATdG0eNAT0n9gJHA1IhYGhFvAlOBg1r6GA7OZpYvrQjOpTfMZW1Mc4eUtDWwK/AE0DciFkExgANbZsMGAPNKdpuf9a2vvyxfEDSzfGnFbdkRMRYYW26MpB7A7cAZEfG2tN4FHs1tiDL9ZTlzNrNciUJU3FoiqTPFwHxzRNyRdS/OyhVkP5dk/fOB0rvHBlJ8UNz6+stycDazfKneag0B1wGzI+Lykk2TgNUrLkYDd5X0H5+t2tgLeCsre0wBRkjqlV0IHJH1leWyhpnlS/UeaLQPcBzwjKSZWd8PgEuBCZJOBF4Bvpxtuwc4BGgAlgMnAETEUkk/ofhUT4ALI2JpSyd3cDazfKnS7dsR8QjN14sB9m9mfAAnr+dY44BxrTm/g7OZ5UtOnq3h4GxmuRJN+bh928HZzPLFmbOZWXoqWSLXETg4m1m+ODibmSUoHyVnB2czy5dozEd0dnA2s3zJR2x2cDazfPEFQTOzFDlzNjNLjzNnM7MUOXM2M0tPNNZ6BtXh4GxmuRLOnM3MEuTgbGaWHmfOZmYJcnA2M0tQNK3327E7FAdnM8sVZ85mZgmKgjNnM7PkOHM2M0tQhDNnM7PkOHM2M0tQwas1zMzS4wuCZmYJcnA2M0tQ5ONxzg7OZpYvzpzNzBLkpXRmZglqyslqjbpaT8DMrJoiVHFriaRxkpZIerak78eSFkiambVDSradI6lB0hxJI0v6D8r6GiSdXcnncHA2s1yJgipuFbgeOKiZ/l9ExC5ZuwdA0hDgKGDHbJ+rJdVLqgd+DRwMDAGOzsaW5bKGmeVKNVdrRMRDkraucPgoYHxErARelNQADMu2NUTEXABJ47Oxz5U7mDNnM8uV1mTOksZImlHSxlR4mlMkPZ2VPXplfQOAeSVj5md96+svy8HZzHKlqVBXcYuIsRExtKSNreAU1wDbArsAi4DLsv7m6iRRpr8slzXMLFfa+iaUiFi8+rWk3wB3Z2/nA4NKhg4EFmav19e/Xs6czSxXCqGK24aQ1K/k7ReA1Ss5JgFHSeoqaRtgMPAkMB0YLGkbSV0oXjSc1NJ5nDmbWa5U8yYUSbcCw4HekuYD5wPDJe1CsTTxEnBS8bwxS9IEihf6GoGTI6IpO84pwBSgHhgXEbNaPHe08f8BVr0+Nyd3uls1deu/b62nYAlqfH/BRkfWpwaNqjjm7DbvrmTvWGnzzLnvNiNbHmQfOIN7tnix2myDbGi5IjUua5hZrjQV8nEpzcHZzHIlL3VUB2czyxWXNczMEuRHhpqZJSgnX77t4Gxm+RLN3i3d8Tg4m1muNLqsYWaWHmfOZmYJcs3ZzCxBzpzNzBLkzNnMLEFNzpzNzNJT2fe2ps/B2cxypeDM2cwsPX7wkZlZgnxB0MwsQQW5rGFmlpymWk+gShyczSxXvFrDzCxBXq1hZpYgr9YwM0uQyxpmZgnyUjozswQ1OXM2M0uPM2czswQ5OJuZJSgnXyHo4Gxm+eLM2cwsQXm5fbuu1hMwM6umgipvLZE0TtISSc+W9G0uaaqkF7KfvbJ+SbpSUoOkpyXtVrLP6Gz8C5JGV/I5HJzNLFcKrWgVuB44aK2+s4FpETEYmJa9BzgYGJy1McA1UAzmwPnAnsAw4PzVAb0cB2czy5VqBueIeAhYulb3KOCG7PUNwOEl/TdG0eNAT0n9gJHA1IhYGhFvAlNZN+Cvw8HZzHIlWtEkjZE0o6SNqeAUfSNiEUD2c8usfwAwr2Tc/Kxvff1l+YKgmeVKa56tERFjgbFVOnVzZ44y/WU5czazXGlqRdtAi7NyBdnPJVn/fGBQybiBwMIy/WU5OJtZrhSIitsGmgSsXnExGrirpP/4bNXGXsBbWdljCjBCUq/sQuCIrK8slzXMLFeqeROKpFuB4UBvSfMprrq4FJgg6UTgFeDL2fB7gEOABmA5cAJARCyV9BNgejbuwohY+yLjOhyczSxXqvmw/Yg4ej2b9m9mbAAnr+c444BxrTm3g7OZ5Ypv3zYzS1Cj8vFFVQ7OZpYr+QjNDs5mljMua5iZJWgjlsglxcHZzHIlH6HZwdnMcsZlDTOzBDXlJHd2cDazXHHmbGaWoHDmbGaWnrxkzn4qXRVddfUlzJn7OI8+8fs1fWedcyrPznmYBx+dxIOPTuKAEZ8BYLfdd1rT99Bjkzj0sANrNW1rQ126duG2+37LxAduZvJD4znl+98A4KJf/IiJD9zMnX+6mSuuu4QPde8GQOcunbl87MXc98TtjL93HP0H9avl9DukdngqXbtQ8VkdbWfzTQen/TdQRXvvswfL3l3GNWP/i332PBQoBudly5bzqyuv+5ex3bptwvvvr6KpqYm+ffvw0J8nM2TwPjQ15eW7g8vr263Fr1DLjQ9178byZSvo1Kmemyb/hkt+dDkNc15k2bvLADjrwjN447WlXHvVjRx9whFsN2QwF3zvUg45/EAOOGQ4Z475YY0/QfuZveTJVjwqv3nf2vrIimPONS9N2OjztRVnzlX050en8+abb1U0dsWK99YE4q6bdKWtf0la7SxftgKATp070blzJyJiTWAG2GSTrmte73fQZ7jrtuL/vKZMvp+99t2jfSebA41ExS1lDs7t4OtjvsLDf57MVVdfwmY9P7ymf/ehO/PYk/fwyON3850zzvvAZM0fNHV1ddxx/0088twUHnvwSZ5+ahYAF//yXB6edS/b/NtW3HTtbQD0/UgfFi1YDEBTUxPvvPMuPTffrGZz74iiFX9StsHBWdIJZbat+dLElasqyyTzaty1t7DbTvvz6U9+nldfXcJFPz1nzba/zPgbnxx2CAcMP4IzzjyJrl271HCm1lYKhQJf3O8rfHbnz/GJXYcweIePAfDD03/CZz5xKHNfeImDRxWvOUjN/C877RiSnGp++3YtbUzmfMH6NkTE2IgYGhFDu3b+YP/Wf+21NygUCkQEN14/gd1232mdMX+f8w+WL1/Bx4dsV4MZWnt55+13efKxp/jUfnuv6SsUCtx751RGfG4/AF5dtIR+A/oCUF9fz6ab9uCfFZbKrOgDkTlLeno97RmgbzvNsUPr27fPmtefO+xAZj/3dwA+utVA6uvrARg4qD//NngbXnllQU3maG2n1xY92fTDPYDitYW9Pz2MFxte5qPbDFwzZvjIfZnb8BIAD0x5iFH/UbyYPPKw/Xj8kRntPueOLi+Zc0vrnPsCI4E31+oX8FibzKgD+824X7DPvsPYYotePPv8w1z601+yz6f25BM7fZyI4JVXFnDmaecCsNfeu3PGmSexalUjhUKB7535Y5a+sfZfs3V0ffr25pKrzqe+vo461XHfpD/y4NRHuWnyWHr06I4knn/uBS743s8A+N3Nk/jZry/gvidu56033+Y7J31wVmpUS1NOLq6XXUon6TrgtxHxSDPbbomIY1o6wQdpKZ1V7oO0lM4qV42ldMds9YWKY84tL09Mdild2cw5Ik4ss63FwGxm1t5SryVXyrdvm1mupF5LrpSDs5nlSuq3ZVfKwdnMcsVlDTOzBOVltYaDs5nlissaZmYJ8gVBM7MEueZsZpYglzXMzBKUl2ej+3nOZpYrTUTFrSWSXpL0jKSZkmZkfZtLmirphexnr6xfkq6U1JA9IG63jfkcDs5mlitt8B2Cn42IXSJiaPb+bGBaRAwGpmXvAQ4GBmdtDHDNxnwOB2czy5WIqLhtoFHADdnrG4DDS/pvjKLHgZ6SNvgbeh2czSxXWpM5l35rU9bGrHW4AP4g6S8l2/pGxCKA7OeWWf8AYF7JvvOzvg3iC4JmliutWUoXEWOBsWWG7BMRCyVtCUyV9HyZsc09fnSD03MHZzPLlWrevh0RC7OfSyRNBIYBiyX1i4hFWdliSTZ8PjCoZPeBwMINPbfLGmaWK9W6ICipu6RNV78GRgDPApOA0dmw0cBd2etJwPHZqo29gLdWlz82hDNnM8uVKt6E0heYmH0jeifgloi4T9J0YIKkE4FXgC9n4+8BDgEagOXACRtzcgdnM8uVat2EEhFzgZ2b6X8D2L+Z/gBOrsrJcXA2s5zx7dtmZgnyg4/MzBLUFPl4aKiDs5nlSl4efOTgbGa54pqzmVmCXHM2M0tQwWUNM7P0OHM2M0uQV2uYmSXIZQ0zswS5rGFmliBnzmZmCXLmbGaWoKZoqvUUqsLB2cxyxbdvm5klyLdvm5klyJmzmVmCvFrDzCxBXq1hZpYg375tZpYg15zNzBLkmrOZWYKcOZuZJcjrnM3MEuTM2cwsQV6tYWaWIF8QNDNLkMsaZmYJ8h2CZmYJcuZsZpagvNSclZffMh2BpDERMbbW87C0+N+FNaeu1hP4gBlT6wlYkvzvwtbh4GxmliAHZzOzBDk4ty/XFa05/ndh6/AFQTOzBDlzNjNLkIOzmVmCHJzbiaSDJM2R1CDp7FrPx2pP0jhJSyQ9W+u5WHocnNuBpHrg18DBwBDgaElDajsrS8D1wEG1noSlycG5fQwDGiJibkS8D4wHRtV4TlZjEfEQsLTW87A0OTi3jwHAvJL387M+M7NmOTi3DzXT5zWMZrZeDs7tYz4wqOT9QGBhjeZiZh2Ag3P7mA4MlrSNpC7AUcCkGs/JzBLm4NwOIqIROAWYAswGJkTErNrOympN0q3An4HtJc2XdGKt52Tp8O3bZmYJcuZsZpYgB2czswQ5OJuZJcjB2cwsQQ7OZmYJcnA2M0uQg7OZWYL+D+OWh25kjeAAAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEICAYAAACDGjUCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAGY9JREFUeJzt3XmYFdW57/Hvr5tBjwODKAEkThc1eG7igGg0JhgjTidB43AcIcaI8eCUm0ETT5yi0ZyoMSbqCScQNVGIV0VwJIg4T6ASUHFAooIQ1KCCgEB3v/ePXXB3oHv3btjde3X5+/jUs2uvWlW1iofn5fWtVbUVEZiZWVpqqj0AMzNbl4OzmVmCHJzNzBLk4GxmliAHZzOzBDk4m5klyMHZWkTSIEnzqj0Os7xzcM4BSW9KWi7pY0l/l3SjpE2rPa4NJSkkLc2u62NJH7bx+f0PkVWNg3N+fD0iNgV2BXYDflzl8VTKFyJi02zp2tKdJXVojUGZtTYH55yJiL8DEykEaQAkHSbpBUmLJc2VdFHRtm2zDHWYpLclvS/p/KLtG2eZ+AeSXgb2LD6fpM9JeljSh5JekvSNom03Srpe0v1Z5vuEpM9IuiY73iuSdluf65R0qqTZkhZJmiCpd9G2kDRC0uvA61nbzpImZf1flXRMUf9DJb0saYmkdyT9QNImwP1A76LMvfc6AzFrJQ7OOSNpa+AQYHZR81JgKNAVOAw4XdLha+36JWAn4ADgAkmfy9ovBHbIloOAYUXn6gjcDfwF2Ao4E7hF0k5Fxz0G+E+gB7ACeAp4Pvt+O3D1elzjV4HLs2P3At4Cxq7V7XBgL6B/FmgnAbdm4zwOuF7SLlnfUcBpEbEZ8K/AQxGxlMKf4/yizH1+S8dqtr4cnPPjLklLgLnAuxSCKgAR8XBEzIyIhoiYAYwBvrLW/hdHxPKI+CvwV+ALWfsxwGURsSgi5gLXFu2zN7ApcEVErIyIh4B7KAS/1cZFxHMR8QkwDvgkIm6OiHrgzxRKMKU8n2XlH0pafe4TgNER8XxErKBQwvmipG2L9rs8G/Ny4N+ANyPiDxFRFxHPA3cAR2V9V1EI4ptHxAfZdrOqcnDOj8OzzG8QsDOFzBQASXtJmiLpPUkfAd8t3p75e9H6MgpBF6A3hYC/2ltF672BuRHRsNb2PkXfFxatL2/ke3M3LnePiK7ZclbRedeMIyI+Bv6x1nmLx7wNsFdRkP+QQoD/TLb9SOBQ4C1Jj0j6YjNjMmt1Ds45ExGPADcCVxY13wpMAPpGRBfgvwGVecgFQN+i758tWp8P9JVUs9b2d1o47JaaTyHgApCVLbZY67zFr1ucCzxSFOS7ZmWK0wEiYmpEDKFQ8rgLuK2RY5i1KQfnfLoGOFDS6puCmwGLIuITSQOB41twrNuAH0vqltWzzyza9gyFevaPJHWUNAj4OuvWfyvtVuBkSbtK6gz8HHgmIt5sov89wI6STsrG2VHSntnNzE6STpDUJSJWAYuB+my/hcAWkrq08vWYrcPBOYci4j3gZuCnWdN/AJdkNekL+P+ZYTkuplBC+BuFG39/LDrPSuAbFG6cvQ9cDwyNiFc29BpKiYjJFK7tDgqZ/Q7AsSX6LwEGZ33mUyjh/ALonHU5CXhT0mIKJZ8Ts/1eoVCfn5OVQzxbw9qM/LJ9M7P0OHM2M0uQg7OZWYIcnM3MEuTgbGaWoFZ/Kcyq9+f4jqOtY+Pe+1V7CJagupXvlDv/vkktiTkde2y/wedrLc6czcwS5Ncpmlm+NNQ336cdcHA2s3ypr6v2CCrCwdnMcuWf38PVfjk4m1m+NDg4m5mlx5mzmVmCfEPQzCxBzpzNzNITnq1hZpYg3xA0M0uQyxpmZgnyDUEzswQ5czYzS5BvCJqZJcg3BM3M0hPhmrOZWXpcczYzS5DLGmZmCXLmbGaWoPpV1R5BRTg4m1m+5KSs4R94NbN8iYbylxIk9ZU0RdIsSS9JOjtrv0jSO5KmZ8uhRfv8WNJsSa9KOqio/eCsbbak88q5DGfOZpYvlcuc64DvR8TzkjYDnpM0Kdv2q4i4srizpP7AscAuQG/gQUk7ZpuvAw4E5gFTJU2IiJdLndzB2czypULBOSIWAAuy9SWSZgF9SuwyBBgbESuAv0maDQzMts2OiDkAksZmfUsGZ5c1zCxXon5V2Yuk4ZKmFS3DGzumpG2B3YBnsqYzJM2QNFpSt6ytDzC3aLd5WVtT7SU5OJtZvrSg5hwRIyNiQNEycu3DSdoUuAM4JyIWAzcAOwC7Usisr1rdtbHRlGgvyWUNM8uXCs7WkNSRQmC+JSLuBIiIhUXb/we4J/s6D+hbtPvWwPxsvan2JjlzNrN8qdxsDQGjgFkRcXVRe6+ibkcAL2brE4BjJXWWtB3QD3gWmAr0k7SdpE4UbhpOaO4ynDmbWb5ULnPeFzgJmClpetb2E+A4SbtSKE28CZwGEBEvSbqNwo2+OmBEZG9hknQGMBGoBUZHxEvNndzB2czypUKPb0fE4zReL76vxD6XAZc10n5fqf0a4+BsZvlS55ftm5mlxy8+MjNLUE7ereHgbGb54szZzCxBzpzNzBLkzNnMLEGerWFmlqBo9rUV7YKDs5nli2vOZmYJcnA2M0uQbwiamSWovr7aI6gIB2czyxeXNczMEuTgbGaWINeczczSEw2e52xmlh6XNczMEuTZGmZmCXLmbGaWIAdnW7DwPX7ysyt5f9EH1EgcNeQQTjrmcF557Q0u+eVvWLFyFbW1tfz0ByP43/13Ys5bc/npZVfz8muzOWv4ME4+/qg1x7p57DjuuPsBJNFvh2259Cf/h86dO1Xx6qw1dO7cmYcfuoNOnTvToUMtd955LxdfchU33/Qb9tjjC6xatYqpU6dz+n+cS11O3q7W5nLy4qOaag+gPetQW8sPzzyVu28dya0jf8XYO+/hjb+9xVXXj+L0b5/AHTddxxnfOZGrrh8FQJfNN+O8732Xbx135D8dZ+F773PL7eP58+hruetP/01DQwP3P/hINS7JWtmKFSv42uBj2GPAgewxYDAHDR7EXgN3Z8yYcezyr19m190OYOONN+KUbx9f7aG2Xw0N5S8JazZzlrQzMAToAwQwH5gQEbNaeWzJ27JHd7bs0R2ATTb5F7bfpi8L3/sHkvh46TIAPl66jK16bAHAFt26skW3rjz65NR1jlVXX8+KFSvpUNuB5Z+sWHNcy5+l2d+Njh070KFjRyKC+x94aM32qVOns/XWvao1vPYvJ1PpSmbOks4FxgICngWmZutjJJ3X+sNrP95ZsJBZr7/B53fZiXPPPo2rrh/FAUecxJW//T3nfPdbJfftuWUPvnXckXztm0PZf8jxbLbJv7DvXnu0zcCtzdXU1DBt6l9Y8M4MJk9+lGenvrBmW4cOHTjhhCOZOHFKFUfYztXXl78krLmyxinAnhFxRUT8KVuuAAZm2xolabikaZKm/f7mMZUcb5KWLVvO986/lHPPOo1NN9mEP4+7l3PPHM7kcX/kR2cN54LLrym5/0eLlzDlsaeZ+H//wEPjb2H5Jyu4e+JDJfex9quhoYEBew5mm+0GsOeA3dhll53WbPvtb37OY489w+NPPFvFEbZv0dBQ9pKy5oJzA9C7kfZe2bZGRcTIiBgQEQO+M/S4DRlf8lbV1XHO+Zdy2OD9OXDQvgBMuP9BvpatH/TV/Zj58qslj/H0tOn06d2T7t260rFDBw74yj5Mn/lyq4/dquujjxbzyKNPctDgQQD89D+/x5ZbbsEPfnhRVcfV7jVE+UvCmgvO5wCTJd0vaWS2PABMBs5u/eGlLSK44PJr2H6bvgw79ptr2rfssQVTX5gJwDPPTWebvn1KHqdXzy2Z8eIrLP/kEyKCZ6ZNZ/tt+rbq2K06evToTpcumwOw0UYbccBX9+PVV9/g2ycfx+ADB3HCiSOInMw2qJpoKH9JWMkbghHxgKQdKZQx+lCoN88DpkZE2gWbNvDCjJe4+4HJ9NthW44cNgKAs08bxsXnnsUVv/4ddfX1dO7UiQt/dBYA7/9jEf9+yll8vHQZNTU1/Om2uxh/y+/4/C47c+D+X+KYk8+ktraWnXfcgaOHHFLNS7NW0qtXT0aPuoba2hpqamq4/fa7ufe+B/lk2Vu89dY8Hn9sAgB33XUfl15WuhxmTUg8Iy6XWvtf6VXvz8nHn5RV1Ma996v2ECxBdSvf0YYeY+kFx5Ydcza5ZOwGn6+1+CEUM8uXxMsV5fJDKGaWLxW6ISipr6QpkmZJeknS2Vl7d0mTJL2efXbL2iXpWkmzJc2QtHvRsYZl/V+XNKycy3BwNrNcqeBUujrg+xHxOWBvYISk/sB5wOSI6EdhcsTqZz4OAfply3DgBigEc+BCYC8K9+8uXB3QS3FwNrN8qVDmHBELIuL5bH0JMIvCxIghwE1Zt5uAw7P1IcDNUfA00FVSL+AgYFJELIqID4BJwMHNXYaDs5nlSwuCc/EDc9kyvLFDStoW2A14BugZEQugEMCBrbJufYC5RbvNy9qaai/JNwTNLF9a8Fh2RIwERpbqI2lT4A7gnIhYLDU5waOxDVGivSRnzmaWK9EQZS/NkdSRQmC+JSLuzJoXZuUKss93s/Z5QPHTY1tTeFFcU+0lOTibWb5UbraGgFHArIi4umjTBGD1jIthwPii9qHZrI29gY+yssdEYLCkbtmNwMFZW0kua5hZvlTuhUb7AicBMyVNz9p+AlwB3CbpFOBt4Ohs233AocBsYBlwMkBELJL0Mwpv9QS4JCIWNXdyB2czy5cKPb4dEY/TeL0Y4IBG+gcwooljjQZGt+T8Ds5mli85ebeGg7OZ5UrU5+PxbQdnM8sXZ85mZukpZ4pce+DgbGb54uBsZpagfJScHZzNLF+iLh/R2cHZzPIlH7HZwdnM8sU3BM3MUuTM2cwsPc6czcxS5MzZzCw9UVftEVSGg7OZ5Uo4czYzS5CDs5lZepw5m5klyMHZzCxBUd/kr2O3Kw7OZpYrzpzNzBIUDc6czcyS48zZzCxBEc6czcyS48zZzCxBDZ6tYWaWHt8QNDNLkIOzmVmCIh+vc3ZwNrN8ceZsZpYgT6UzM0tQfU5ma9RUewBmZpUUobKX5kgaLeldSS8WtV0k6R1J07Pl0KJtP5Y0W9Krkg4qaj84a5st6bxyrsPB2cxyJRpU9lKGG4GDG2n/VUTsmi33AUjqDxwL7JLtc72kWkm1wHXAIUB/4Lisb0kua5hZrlRytkZEPCpp2zK7DwHGRsQK4G+SZgMDs22zI2IOgKSxWd+XSx3MmbOZ5UpLMmdJwyVNK1qGl3maMyTNyMoe3bK2PsDcoj7zsram2ktycDazXKlvqCl7iYiRETGgaBlZxiluAHYAdgUWAFdl7Y3VSaJEe0kua5hZrrT2QygRsXD1uqT/Ae7Jvs4D+hZ13RqYn6031d4kZ85mlisNobKX9SGpV9HXI4DVMzkmAMdK6ixpO6Af8CwwFegnaTtJnSjcNJzQ3HmcOZtZrlTyIRRJY4BBQA9J84ALgUGSdqVQmngTOK1w3nhJ0m0UbvTVASMioj47zhnARKAWGB0RLzV77mjl/wdY9f6cnDzpbpW0ce/9qj0ES1Ddync2OLI+33dI2TFn97njk31ipdUz517bNzZF0D7ttu/Sq/lOZuthfcsVqXFZw8xypb4hH7fSHJzNLFfyUkd1cDazXHFZw8wsQX5lqJlZgnLy49sOzmaWL9Ho09Ltj4OzmeVKncsaZmbpceZsZpYg15zNzBLkzNnMLEHOnM3MElTvzNnMLD3l/W5r+hyczSxXGpw5m5mlxy8+MjNLkG8ImpklqEEua5iZJae+2gOoEAdnM8sVz9YwM0uQZ2uYmSXIszXMzBLksoaZWYI8lc7MLEH1zpzNzNLjzNnMLEEOzmZmCcrJTwg6OJtZvjhzNjNLUF4e366p9gDMzCqpQeUvzZE0WtK7kl4sausuaZKk17PPblm7JF0rabakGZJ2L9pnWNb/dUnDyrkOB2czy5WGFixluBE4eK2284DJEdEPmJx9BzgE6Jctw4EboBDMgQuBvYCBwIWrA3opDs5mliuVDM4R8SiwaK3mIcBN2fpNwOFF7TdHwdNAV0m9gIOASRGxKCI+ACaxbsBfh4OzmeVKtGCRNFzStKJleBmn6BkRCwCyz62y9j7A3KJ+87K2ptpL8g1BM8uVlrxbIyJGAiMrdOrGzhwl2kty5mxmuVLfgmU9LczKFWSf72bt84C+Rf22BuaXaC/JwdnMcqWBKHtZTxOA1TMuhgHji9qHZrM29gY+ysoeE4HBkrplNwIHZ20luaxhZrlSyYdQJI0BBgE9JM2jMOviCuA2SacAbwNHZ93vAw4FZgPLgJMBImKRpJ8BU7N+l0TE2jcZ1+HgbGa5UsmX7UfEcU1sOqCRvgGMaOI4o4HRLTm3g7OZ5Yof3zYzS1Cd8vFDVQ7OZpYr+QjNDs5mljMua5iZJWgDpsglxcHZzHIlH6HZwdnMcsZlDTOzBNXnJHd2cDazXHHmbGaWoHDmbGaWnrxkzn4rXQX9+rqfM+uNp3js6XvWtP3+D9cw5fHxTHl8PM/PfIgpjxdeYNWte1fuuudm3pz/AldceUG1hmytrFPnTtw+8SYmTLmVex/7M2f9qPAu9xNPOYZJz47jtfem0a17lzX9v37kwUx4eAwTHh7D2HtHsfMu/ao19HarDd5K1yacOVfQ2FvuZNTIP3Hd7/5rTdt3Tj5nzfoll53H4sVLAFjxyQouv/TXfK5/P3buv2Obj9XaxsoVKxn6ze+ybOlyOnSoZcw9o3hk8pM89+xfmfKXx/jjXb/7p/7z3p7PiUOGs/ijJXz5gH342VXnc/TB36rO4NuptENu+RycK+ipJ6fR97NN//rMkCMO4YivDwVg2bLlPPP0c2y3/WfbanhWJcuWLgegQ8cOdOjYgYhg1sxXG+37wtQZa9anT5vJZ3pv1Wg/a1pdTsKzyxpt5Iv7DOC9d99nzhtvVXso1sZqamoYP+UWnpo1iScefoYZz79U1n5HnTCERyc/2cqjy59owX8pW+/gLOnkEtvW/GjiJys/Wt9T5Mo3j/o37rz93moPw6qgoaGBIfufwJc/fyif330X+u28Q7P77LXvHhx9whB+eclv2mCE+VLJX9+upg3JnC9uakNEjIyIARExYKNOXZrq9qlRW1vLYd8YzLg7HZw/zZYs/phnn3iO/b76xZL9dur/v7jsVz/l9JO+z4cfOLlpqbxkziVrzpJmNLUJ6Fn54eTTV/bfh9mvzWHB/IXVHoq1sW5bdKVuVR1LFn9M5406s89XBjLy2pua7N+rT09+e+Mv+eGIC3hzztttONL8SD0jLldzNwR7AgcBH6zVLsDFsLWMHH01+35pIN236MaMWY/yi59fyy1/vJ0jjjyMO2+/Z53+z898iM0235SOHTty6GFf46jDT+a1V9+owsittWzVswe/+O3F1NTUUFNTw/3jJ/HwpMc56dR/59QzhtJjqy2Y8MhYHn3wCc7/3qWc8YNT6dqtCxf917kA1NXVc+SBQ6t8Fe1LfaSdEZdLUeJCJI0C/hARjzey7daIOL65E/TYfMd8/ElZRXXvvHm1h2AJeu29adrQYxy/zRFlx5xb3xq3wedrLSUz54g4pcS2ZgOzmVlbS72WXC7PczazXPm01JzNzNqV1B/LLpeDs5nlissaZmYJystsDQdnM8sVlzXMzBLkG4JmZglyzdnMLEEua5iZJajUU8/tid/nbGa5Uk+UvTRH0puSZkqaLmla1tZd0iRJr2ef3bJ2SbpW0mxJMyTtviHX4eBsZrnSCr8huH9E7BoRA7Lv5wGTI6IfMDn7DnAI0C9bhgM3bMh1ODibWa5ERNnLehoCrH7v603A4UXtN0fB00BXSb3W9yQOzmaWKy3JnIt/tSlbhq91uAD+Ium5om09I2IBQPa5+oce+wBzi/adl7WtF98QNLNcaclUuogYCYws0WXfiJgvaStgkqRXSvRt7PWj652eOzibWa5U8vHtiJiffb4raRwwEFgoqVdELMjKFu9m3ecBfYt23xqYv77ndlnDzHKlUjcEJW0iabPV68Bg4EVgAjAs6zYMGJ+tTwCGZrM29gY+Wl3+WB/OnM0sVyr4EEpPYJwkKMTKWyPiAUlTgdsknQK8DRyd9b8POBSYDSwDTt6Qkzs4m1muVOohlIiYA3yhkfZ/AAc00h7AiIqcHAdnM8sZP75tZpYgv/jIzCxB9ZGPl4Y6OJtZruTlxUcOzmaWK645m5klyDVnM7MENbisYWaWHmfOZmYJ8mwNM7MEuaxhZpYglzXMzBLkzNnMLEHOnM3MElQf9dUeQkU4OJtZrvjxbTOzBPnxbTOzBDlzNjNLkGdrmJklyLM1zMwS5Me3zcwS5JqzmVmCXHM2M0uQM2czswR5nrOZWYKcOZuZJcizNczMEuQbgmZmCXJZw8wsQX5C0MwsQc6czcwSlJeas/Lyr0x7IGl4RIys9jgsLf57YY2pqfYAPmWGV3sAliT/vbB1ODibmSXIwdnMLEEOzm3LdUVrjP9e2Dp8Q9DMLEHOnM3MEuTgbGaWIAfnNiLpYEmvSpot6bxqj8eqT9JoSe9KerHaY7H0ODi3AUm1wHXAIUB/4DhJ/as7KkvAjcDB1R6EpcnBuW0MBGZHxJyIWAmMBYZUeUxWZRHxKLCo2uOwNDk4t40+wNyi7/OyNjOzRjk4tw010uY5jGbWJAfntjEP6Fv0fWtgfpXGYmbtgINz25gK9JO0naROwLHAhCqPycwS5uDcBiKiDjgDmAjMAm6LiJeqOyqrNkljgKeAnSTNk3RKtcdk6fDj22ZmCXLmbGaWIAdnM7MEOTibmSXIwdnMLEEOzmZmCXJwNjNLkIOzmVmC/h8NvRI6GSDAagAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 2 Axes>"
       ]
@@ -1670,7 +1701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1692,22 +1723,22 @@
       "               precision    recall  f1-score   support\n",
       "\n",
       "           0       0.92      0.99      0.95      2850\n",
-      "           1       0.89      0.50      0.64       483\n",
+      "           1       0.87      0.49      0.63       483\n",
       "\n",
       "   micro avg       0.92      0.92      0.92      3333\n",
-      "   macro avg       0.91      0.75      0.80      3333\n",
-      "weighted avg       0.92      0.92      0.91      3333\n",
+      "   macro avg       0.90      0.74      0.79      3333\n",
+      "weighted avg       0.91      0.92      0.91      3333\n",
       "\n",
       "\n",
       "Random Forest Classifier:\n",
       "               precision    recall  f1-score   support\n",
       "\n",
-      "           0       0.94      0.99      0.97      2850\n",
-      "           1       0.93      0.64      0.76       483\n",
+      "           0       0.94      0.99      0.96      2850\n",
+      "           1       0.89      0.65      0.75       483\n",
       "\n",
       "   micro avg       0.94      0.94      0.94      3333\n",
-      "   macro avg       0.93      0.82      0.86      3333\n",
-      "weighted avg       0.94      0.94      0.94      3333\n",
+      "   macro avg       0.92      0.82      0.86      3333\n",
+      "weighted avg       0.94      0.94      0.93      3333\n",
       "\n",
       "\n"
      ]
@@ -1735,7 +1766,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1752,7 +1783,7 @@
        "              verbose=0, warm_start=False)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1764,32 +1795,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.00231965 0.00328351 0.00092648 0.09486837 0.02245592 0.06108225\n",
-      " 0.17959752 0.00385574 0.11057833 0.08123595 0.00135536 0.06056395\n",
-      " 0.01024578 0.00122899 0.00843451 0.056446   0.11086928 0.02722142\n",
-      " 0.16343101]\n"
+      "[0.00190342 0.00316478 0.00029818 0.09486837 0.04225292 0.04111695\n",
+      " 0.13667176 0.0043927  0.15416851 0.08124499 0.00154907 0.0609312\n",
+      " 0.01116761 0.00062346 0.00764751 0.05963872 0.11125285 0.02389242\n",
+      " 0.16321456]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7b4c1104a8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7feb400a3358>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsEAAAJCCAYAAAAhlRoCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xu4nWV95//3h4QGEUi0RBsYp9vSUMpBogYqZ3DQsYVpdUDjoRaqbX4OP2VMyzAZqxanrRMm/kZGKZ0GfjZzYGILCEWpgsohihxyICeoh2sgPUTECjZyECrhO3+sO+1ys3fW3hDYh+f9uq59sdbzfJ/7/j5P+OOTe99rJVWFJEmS1CV7THQDkiRJ0vPNECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjpn5kQ3oMlv//33r6GhoYluQ5IkaaB169Z9r6rmDqozBGugoaEh1q5dO9FtSJIkDZTkr8ZS53YISZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWANt3radoaXXMbT0uoluRZIkabcwBEuSJKlzDMGSJEnqHEOwJEmSOscQ3AFJzk5y8UT3IUmSNFkYgp8nSWZMdA+SJEnqMQTvBkmuSbIuyd1JFvcdfyTJf0xyB3BMklcnuaXVXp9kXqv7zSRrkmxMclWSvUeYY58kf5Jkc5JNSc5ox9/Wjm1JcmFf/a8n+WaSW4Dj+o7PbXOsaT/HDZ9LkiRpujME7x7vqqpXAwuBc5P8ZDv+QmBLVf0CcAfwSeDMVvsp4A9a3Weq6qiqOhL4S+DdI8zxIWB7VR1RVa8AbkxyAHAh8FpgAXBUkje2cP0ReuH3dcChfeP8V+DjVXUUcAZw2W56BpIkSVPGzIluYJo4N8mb2uuXAfOBB4EdwFXt+M8BhwNfTAIwA7i/nTs8ye8Dc4B9gOtHmONU4K0731TV95OcCNxcVX8HkORy4MRW0n/8T4GD+8Y5tPUAsF+Sfavq4f7J2or2YoAZ+80d+5OQJEmaAgzBz1KSk+kFy2Oq6rEkNwN7tdOPV9WOnaXA3VV1zAjDrATeWFUbk5wNnDzSVECNcGw0w2t32qP1+sNdXEtVrQBWAMyaN3+0sSRJkqYkt0M8e7OB77cAfAjwmlHqvgHMTXIMQJI9kxzWzu0L3J9kT+Ado1x/A/DenW+SvIjeFouTkuzfPnj3NuCWdvzkJD/ZxnzzLsZZML7blSRJmvoMwc/eF4CZSTYBvwfcPlJRVf0DcCZwYZKNwAbg2Hb6Q/SC6xeBr48yz+8DL2ofgNsInFJV9wP/AbgJ2Aisr6o/b8cvAG4DvgSs7xvnXGBh+3DdPcB7ntltS5IkTV2p8jfd2rVZ8+bXvLMuAmDrstMmuBtJkqTRJVlXVQsH1bkSLEmSpM4xBEuSJKlz/HYIDXTEgbNZ6zYISZI0jbgSLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBGugzdu2M7T0OoaWXjfRrUiSJO0WhmBJkiR1jiFYkiRJnWMIliRJUudMuxCcZE6Sc8ZQN5Tk7WOs2zLOHi5LcuiAmpVJznymfY2xjwuSnLer+SRJkrpo2oVgYA4wMAQDQ8BuCZvDVdVvVNU9z/DyIZ6jviRJktQzHUPwMuCgJBuSLE/P8iRbkmxOsqiv7oRWt6StwH4lyfr2c+yuJklycpKbk1yZ5OtJLk+Sdu7mJAvb63cn+WY7dmmSi/uGOTHJ15Lc27dK+2N9jTDv+e0+NiZZ1o79ZpI17dhVSfYe0PuyJPck2ZTkY2N5qJIkSdPJzIlu4DmwFDi8qhYAJDkDWAAcCewPrEmyutWdV1Wnt7q9gddV1eNJ5gOrgIUD5nolcBjwbeBW4DjgqztPJjkA+BDwKuBh4EZgY9/184DjgUOAa4Erh/fVL8kvAm8EfqGqHkvy4nbqM1V1aav5feDdwCdHarhd8ybgkKqqJHNGqVsMLAaYsd/cAY9BkiRpapmOK8HDHQ+sqqodVfUAcAtw1Ah1ewKXJtkMXAHsck9vc2dV/W1VPQVsoLeVod/RwC1V9VBV/aiN2++aqnqqbZ146RjmOxX4k6p6DKCqHmrHD2+r2JuBd9AL5qP5AfA4cFmSfw08NlJRVa2oqoVVtXDG3rPH0JokSdLU0YUQnDHWLQEeoLdivBD4iTFc80Tf6x08fWV90Nz914+lzwA1wvGVwHur6gjgI8Beow1QVU/SC+dX0VtV/sIY5pUkSZpWpmMIfhjYt+/9amBRkhlJ5gInAneOUDcbuL+t6r4TmLEberkTOCnJi5LMBM54Bv33uwF41849v33bIfYF7k+yJ72V4FEl2QeYXVV/Abyf3lYRSZKkTpl2e4Kr6sEkt7avNfs8cD5wDL29uAWcX1XfSfIg8GSSjfRWUi8BrkryZuAm4NHd0Mu2JB8F7qC3b/geYPuAyzb191VVH+8b7wtJFgBrk/wD8BfAB+jtO74D+CtgM6OHaNq5P0+yF72V5ad9+E6SJGm6S9VIv13X7pJkn6p6pK0EXw18qqqunui+xmPWvPk176yLANi67LQJ7kaSJGl0SdZV1aAvN5iW2yEmmwuSbAC2APcB10xwP5IkSZ3nSrAGWrhwYa1du3ai25AkSRrIlWBJkiRpFIZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdc7MiW5Ak9/mbdsZWnrdP77fuuy0CexGkiTp2XMlWJIkSZ1jCJYkSVLndC4EJ5mT5Jwx1A0lefsY67bsnu52ryQnJ/lce312kosnuidJkqTJoHMhGJgDDAzBwBAwMARLkiRp6uliCF4GHJRkQ5Ll6VmeZEuSzUkW9dWd0OqWtBXfryRZ336OHTRRkn+XZE2STUk+0o5d2L8SneSCJL89Wv0IY76hzb8xyZfbsaOTfC3JXe2/Pzegrze3+92YZPWYnpokSdI00sVvh1gKHF5VCwCSnAEsAI4E9gfWtGC4FDivqk5vdXsDr6uqx5PMB1YBC0ebJMnrgfnA0UCAa5OcCHwauAi4pJW+BXjDaPVVtbpvzLnApcCJVXVfkhe3U19vx55McirwUeCMXTyDDwP/sqq2JZkzhmcmSZI0rXQxBA93PLCqqnYADyS5BTgK+MGwuj2Bi5MsAHYABw8Y9/Xt5672fh9gflX9/0lekuQAYC7w/ar66yTnjlQP9K/UvgZYXVX3AVTVQ+34bOC/t3BerddduRVYmeTPgM+MVJBkMbAYYMZ+cwcMJ0mSNLUYgnurrmOxBHiA3orxHsDjYxj3P1XVH49w7krgTOCn6K0MD6rvH7NGOP57wE1V9aYkQ8DNu2qsqt6T5BeA04ANSRZU1YPDalYAKwBmzZs/0pySJElTVhf3BD8M7Nv3fjWwKMmMtt3gRODOEepmA/dX1VPAO4EZA+a5HnhXkn0AkhyY5CXt3KeBt9ILwleOoX6n24CTkry81ezcDjEb2NZenz2gL5IcVFV3VNWHge8BLxt0jSRJ0nTSuZXgqnowya3ta80+D5wPHANspLfKen5VfSfJg8CTSTYCK+nt4b0qyZuBm4BHB8xzQ5KfB25LAvAI8KvAd6vq7iT7Atuq6v5B9X1j/l3bpvCZJHu0c68D/jO97RC/Bdw4hsewvG2dCPDldu+SJEmdkSp/061dmzVvfs0766J/fO8/myxJkiarJOuqatQvL9ipi9shJEmS1HGGYEmSJHVO5/YEa/yOOHA2a90CIUmSphFXgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5Mye6AU1+m7dtZ2jpdSOe27rstOe5G0mSpGfPlWBJkiR1jiFYkiRJnWMIliRJUucYgqeoJO9PsvfuqpMkSeoSQ/DU9X5gLOF2rHWSJEmdYQieApK8MMl1STYm2ZLkd4EDgJuS3NRq/ijJ2iR3J/lIO3buCHWvT3JbkvVJrkiyz0TdlyRJ0kQxBE8NbwC+XVVHVtXhwEXAt4FTquqUVvM7VbUQeAVwUpJXVNUn+uuS7A98EDi1ql4FrAV+a6QJkyxuoXrtjse2P8e3J0mS9PwyBE8Nm4FTk1yY5ISqGimVviXJeuAu4DDg0BFqXtOO35pkA3AW8NMjTVhVK6pqYVUtnLH37N1zF5IkSZOE/1jGFFBV30zyauCXgP+U5Ib+80leDpwHHFVV30+yEthrhKECfLGq3vZc9yxJkjSZuRI8BSQ5AHisqv4X8DHgVcDDwL6tZD/gUWB7kpcCv9h3eX/d7cBxSX62jbt3koOfh1uQJEmaVFwJnhqOAJYneQr4EfBvgGOAzye5v+33vQu4G7gXuLXv2hXD6s4GViWZ1c5/EPjm83UjkiRJk0GqaqJ70CQ3a978mnfWRSOe27rstOe5G0mSpNElWde+LGCX3A4hSZKkznE7hAY64sDZrHXFV5IkTSOuBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqnJkT3YAmv83btjO09LqBdVuXnfY8dCNJkvTsuRIsSZKkzjEES5IkqXMMwc+jJENJ3r6Lc1uegzlPTnJs3/uVSc7c3fNIkiRNJYbg59cQMGIIfg6dDBw7qEiSJKlLpn0ITnJNknVJ7k6yuO/4G5KsT7IxyZfbsX2S/EmSzUk2JTmjHX9bO7YlyYV9YzzS9/rMJCvb65VJPpHka0nu7Vt5XQackGRDkiW76HlGkuVJ1rQ+/p92/OQkNye5MsnXk1yeJO3cL7VjX21zfy7JEPAeYEmb84Q2xYkj9CZJktQZXfh2iHdV1UNJXgCsSXIVvfB/KXBiVd2X5MWt9kPA9qo6AiDJi5IcAFwIvBr4PnBDkjdW1TUD5p0HHA8cAlwLXAksBc6rqtMHXPvu1sdRSWYBtya5oZ17JXAY8G3gVuC4JGuBP+67n1UAVbU1yX8DHqmqj7V7evcovUmSJHXGtF8JBs5NshG4HXgZMB94DbC6qu4DqKqHWu2pwB/uvLCqvg8cBdxcVX9XVU8ClwMnjmHea6rqqaq6B3jpOHt+PfBrSTYAdwA/2foGuLOq/raqngI20NticQhw7877AVY9296SLE6yNsnaHY9tH2f7kiRJk9u0XglOcjK9YHtMVT2W5GZgLyBAjXTJCMeziyn6a/cadu6JMY4xkgDvq6rrf+xg7376x91B789wvOMP7K2qVgArAGbNmz/Ss5IkSZqypvtK8Gzg+y0AH0JvBRjgNuCkJC8H6NsOcQPw3p0XJ3kRvZXYk5Lsn2QG8DbgllbyQJKfT7IH8KYx9PMwsO8Y6q4H/k2SPVsfByd54S7qvw78TNsDDLDoGcwpSZLUGdM9BH8BmJlkE/B79LZEUFV/BywGPtO2Svxpq/994EXtA3AbgVOq6n7gPwA3ARuB9VX1561+KfA54Ebg/jH0swl4sn0Yb9QPxgGXAfcA69vXpv0xu1i1r6ofAucAX0jyVeABYOcehs8Cbxr2wThJkqROS5W/6Z4OkuxTVY+0b4v4Q+BbVfXx3TH2rHnza95ZFw2s859NliRJEy3JuqpaOKhuuq8Ed8lvtg/S3U1vG8gfT3A/kiRJk9a0/mBcl7RV392y8itJkjTdGYI10BEHzmatWx0kSdI04nYISZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdc7MiW5Ak9/mbdsZWnrdmGq3LjvtOe5GkiTp2XMlWJIkSZ1jCJYkSVLnGIIlSZLUOZ0LwUnmJDlnDHVDSd4+xrotY6hbmeTMsfa5uyR5pP13TH1KkiR1QedCMDAHGBiCgSFgYAiWJEnS1NPFELwMOCjJhiTL07M8yZYkm5Ms6qs7odUtaSupX0myvv0cu6tJ2rgXJ7knyXXAS/rOfTjJmjbnilZ7UJL1fTXzk6wbYdyfTfKlJBtbHwcl2SfJl9v7zUl+ZUBvhyW5s93bpiTzx/MAJUmSproufkXaUuDwqloAkOQMYAFwJLA/sCbJ6lZ3XlWd3ur2Bl5XVY+30LgKWLiLed4E/BxwBPBS4B7gU+3cxVX1H9u4/xM4vao+m2R7kgVVtQH4dWDlCONeDiyrqquT7EXvLzL/ALypqn6QZH/g9iTXVlWN0tt7gP9aVZcn+Qlgxq4fmSRJ0vTSxZXg4Y4HVlXVjqp6ALgFOGqEuj2BS5NsBq4ADh0w7ol9434buLHv3ClJ7mhjvRY4rB2/DPj1JDOARcD/7h8wyb7AgVV1NUBVPV5VjwEBPppkE/Al4EB6wXs0twEfSPLvgZ+uqh8OL0iyOMnaJGt3PLZ9wK1KkiRNLYbgXoAciyXAA/RWjBcCPzGGa562EttWby8BzqyqI4BLgb3a6auAXwROB9ZV1YNj7PUdwFzg1W2F+4G+MZ/eVNX/Bn4Z+CFwfZLXjlCzoqoWVtXCGXvP3sUtSpIkTT1dDMEPA/v2vV8NLEoyI8lceiu4d45QNxu4v6qeAt7J4C0Eq4G3tnHnAae04zvD6feS7AP84zdGVNXjwPXAHwF/MnzAqvoB8LdJ3giQZFbbpjEb+G5V/SjJKcBP76qxJD8D3FtVnwCuBV4x4F4kSZKmlc6F4La6emv7UNpy4GpgE7CR3paF86vqO+3Yk+0DaEvord6eleR24GDg0QFTXQ18C9hML9Te0ub/e3qrv5uBa4A1w667nN4K8g2jjPtO4Ny29eFrwE+1axYmWUtvVfjrA3pbBGxJsgE4BPgfA+olSZKmlYz+2SlNhCTnAbOr6kMT3ctOs+bNr3lnXTSm2q3LTnuOu5EkSRpdknVVtasvLwC6+e0Qk1aSq4GD6H1YTpIkSc8RQ/AkUlVvmugeJEmSusAQrIGOOHA2a93mIEmSppHOfTBOkiRJMgRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOmTnRDWjy27xtO0NLr3tO59i67LTndHxJkqR+rgRLkiSpcwzBkiRJ6hxDsCRJkjpn0ofgJHOSnDOGuqEkbx9j3ZZx9nBZkkMH1KxMcuYz7WvYNTcnWTieayRJkjR2kz4EA3OAgSEYGALGFTbHqqp+o6rueYaXD/Ec9TWSJDOer7kkSZKmqqkQgpcBByXZkGR5epYn2ZJkc5JFfXUntLolbQX2K0nWt59jdzVJkpPbCuyVSb6e5PIkaef+cWU2ybuTfLMduzTJxX3DnJjka0nu7VsV/rG+Rpj3/HYfG5Ms6zv15iR3trlOaLUj3lPr/aYk/xvY3I59qN3HF5OsSnJeO35Qki8kWdfGOmR8fxySJElT31T4irSlwOFVtQAgyRnAAuBIYH9gTZLVre68qjq91e0NvK6qHk8yH1gFDNpi8ErgMODbwK3AccBXd55McgDwIeBVwMPAjcDGvuvnAccDhwDXAlcO76tfkl8E3gj8QlU9luTFfadnVtXRSX4J+F3gVOC7u7ino9tzuq8F9jPa/cwE1gPrWt0K4D1V9a0kvwBcArx2hN4WA4sBZuw3d8BjkyRJmlqmQgge7nhgVVXtAB5IcgtwFPCDYXV7AhcnWQDsAA4ew9h3VtXfAiTZQG8rw1f7zh8N3FJVD7WaK4aNe01VPQXck+SlY5jvVOBPquoxgJ3jNp9p/13X+hh0T3dW1X3t9fHAn1fVD1ufn23/3Qc4FriiLXIDzBqpsapaQS8wM2ve/BrDvUiSJE0ZUzEEZ3AJAEuAB+itGO8BPD6Ga57oe72Dpz+fQXP3Xz+WPgOMFjB3jtXfx67u6dExzL0H8Pc7V9UlSZK6airsCX4Y2Lfv/WpgUZIZSeYCJwJ3jlA3G7i/rcy+E9gdHxi7EzgpyYuSzKS35WC8/fe7AXhX27rBsO0QIxnrPX0V+FdJ9mqrv6cBVNUPgPuSvLnNlyRHjuEeJEmSppVJH4Kr6kHg1vZBuOXA1cAmentxbwTOr6rvtGNPtg+YLaG31/WsJLfT2zbw6MgzjKuXbcBHgTuALwH3ANsHXDa8r/7xvkBv7/Datv3ivAFjjemeqmpNG3cjvW0Va/v6fAfw7iQbgbuBXxkwpyRJ0rSTKrd7jkeSfarqkbYSfDXwqaq6eqL7Gq6vz73prZ4vrqr1z2SsWfPm17yzLtq9DQ6zddlpz+n4kiSpG5Ksq6qB/97CVNwTPNEuSHIqsBe97QzXTHA/o1nR/oGPvYD//kwDsCRJ0nTkSrAGWrhwYa1du3ai25AkSRporCvBk35PsCRJkrS7GYIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOTMnugFNfpu3bWdo6XXP+7xbl532vM8pSZK6wZVgSZIkdY4hWJIkSZ0zaUJwkjlJzhlD3VCSt4+xbss4e7gsyaEDalYmOfOZ9jVg7Pck+bVncf0Hns38kiRJXTFpQjAwBxgYgoEh4FmFzdFU1W9U1T3P8PIhnmVfVfXfqup/PIshDMGSJEljMJlC8DLgoCQbkixPz/IkW5JsTrKor+6EVrekrcB+Jcn69nPsriZJcnKSm5NcmeTrSS5Pknbu5iQL2+t3J/lmO3Zpkov7hjkxydeS3Nu3KvxjfY0w5y1J/qyNuSzJO5Lc2e7toFZ3QZLz+nq5sNV8M8kJ7fjZ/b0k+Vwbfxnwgjb/5e3cr7brNyT54yQz2s/Kvuf6Y71KkiR1wWT6doilwOFVtQAgyRnAAuBIYH9gTZLVre68qjq91e0NvK6qHk8yH1gFLBww1yuBw4BvA7cCxwFf3XkyyQHAh4BXAQ8DNwIb+66fBxwPHAJcC1w5vK8RHAn8PPAQcC9wWVUdneTfAu8D3j/CNTNbzS8BvwucOtoNVdXSJO/te34/DywCjquqHyW5BHgHcDdwYFUd3urmjDamJEnSdDWZVoKHOx5YVVU7quoB4BbgqBHq9gQuTbIZuALY5Z7e5s6q+tuqegrYQG8rQ7+jgVuq6qGq+lEbt981VfVU2zrx0jHez5qqur+qngD+D3BDO755hPl3+kz777pd1IzmXwCvpveXhw3t/c/QC+A/k+STSd4A/GCki5MsTrI2ydodj20f59SSJEmT22RaCR4uY6xbAjxAb6V1D+DxMVzzRN/rHTz9OQyau//6sfbZf81Tfe+fGmH+4df09/gkP/6Xl71GuTbAf6+q//C0E8mRwL8E/l/gLcC7htdU1QpgBcCsefNrlDkkSZKmpMm0EvwwsG/f+9XAoraHdS5wInDnCHWzgfvbqu47gRm7oZc7gZOSvCjJTOCMZ9D/c2UrsCDJHkleRm/VeqcfJdmzvf4ycGaSlwAkeXGSn06yP7BHVV3FP235kCRJ6pRJsxJcVQ8mubV9rdnngfOBY+jtxS3g/Kr6TpIHgSeTbARWApcAVyV5M3AT8Ohu6GVbko8Cd9DbN3wPMGhPwKb+vqrq48+2j1HcCtxHbxvFFmB937kVwKYk66vqHUk+CNyQZA/gR/RWfn8I/Ek7BvC0lWJJkqTpLlX+pnskSfapqkfaSvDVwKeq6uqJ7msizJo3v+adddHzPq//bLIkSRqvJOuqatCXJEyq7RCTzQXtA2Vb6K28XjPB/UiSJGk3mTTbISabqjpvonuQJEnSc8MQrIGOOHA2a92aIEmSphG3Q0iSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzZk50A5r8Nm/bztDS6ya6jQm3ddlpE92CJEnaTVwJliRJUucYgiVJktQ5hmBJkiR1jiG4SXJAkisnQR+XJTm0vd6aZP9xXLsyyZnPXXeSJEnTgx+Ma6rq28CEB8iq+o2J7kGSJGm6m7YrwUkuTHJO3/sLkvx2epYn2ZJkc5JF7fxQki3t9YwkH2vnNyV5Xzv+6iS3JFmX5Pok80aYd2WSP0pyU5J7k5yU5FNJ/jLJyr66P0qyNsndST7Sd/zmJAsH3NsjSf6/JOuTfDnJ3BFqPpxkTbvPFUnSN/6FSe5M8s0kJ4z74UqSJE1x0zYEA58GFvW9fwtwBfCvgQXAkcCpwPIRwuxi4OXAK6vqFcDlSfYEPgmcWVWvBj4F/MEoc78IeC2wBPgs8HHgMOCIJAtaze9U1ULgFcBJSV4xjnt7IbC+ql4F3AL87gg1F1fVUVV1OPAC4PS+czOr6mjg/aNcS5LFLaSv3fHY9nG0JkmSNPlN2xBcVXcBL2l7fY8Evl9Vfw0cD6yqqh1V9QC9EHnUsMtPBf5bVT3ZxnoI+DngcOCLSTYAHwT+2SjTf7aqCtgMPFBVm6vqKeBuYKjVvCXJeuAuegH50HHc3lPAn7bX/6vd03CnJLkjyWZ6gfywvnOfaf9d19fPj6mqFVW1sKoWzth79jhakyRJmvym+57gK+nt8/0peivDABnDdQFqhGN3V9UxY7j+ifbfp/pe73w/M8nLgfOAo6rq+22bxF5jGHc0P9Zrkr2AS4CFVfU3SS4YNv7OnnYw/f8fkCRJepppuxLcfBp4K70gvPObH1YDi9q+37nAicCdw667AXhPkpkASV4MfAOYm+SYdmzPJIfxzOwHPApsT/JS4BfHef0e/NOH+N4OfHXY+Z2B93tJ9mESfOC0H9SnAAAgAElEQVRPkiRpMpnWq4BVdXeSfYFtVXV/O3w1cAywkd4K6vlV9Z0kQ32XXgYcDGxK8iPg0qq6uH392CeSzKb37C6it8VhvH1tTHJXu/Ze4NZxDvEocFiSdcB2fnzvM1X190kupbcdYyuwZrw9SpIkTWfpbV3VVJLkkara5/mab9a8+TXvrIuer+kmra3LTpvoFiRJ0gBJ1rUvH9il6b4dQpIkSXoaQ/AU9HyuAkuSJE1H03pPsHaPIw6czVq3AkiSpGnElWBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1zsyJbkCT3+Zt2xlaet1EtzFlbV122kS3IEmShnElWJIkSZ1jCJYkSVLnTJsQnGROknPGUDeU5O1jrNsywvEDklw5hus/MOz9I4Ou6atdmeTMsdZLkiRpfKZNCAbmAANDMDAEDAzBo6mqb1fVWALqBwaX7H7pmU5/rpIkSbvddApLy4CDkmxIsryFweVJtiTZnGRRX90JrW5JW/H9SpL17efYXU3Sv0Kc5Owkn0nyhSTfSvKf2/FlwAvaHJcPGO/XkmxKsjHJ/+w7dWKSryW5d+eqcJJ9kny59bk5ya/09fSXSS4B1gMvS/LuJN9McnOSS5Nc3GrnJrkqyZr2c9y4n7QkSdIUN52+HWIpcHhVLQBIcgawADgS2B9Yk2R1qzuvqk5vdXsDr6uqx5PMB1YBC8cx7wLglcATwDeSfLKqliZ5785eRpPkMOB3gOOq6ntJXtx3eh5wPHAIcC1wJfA48Kaq+kGS/YHbk1zb6n8O+PWqOifJAcCHgFcBDwM3Ahtb3X8FPl5VX03yz4HrgZ8fx/1KkiRNedMpBA93PLCqqnYADyS5BTgK+MGwuj2Bi5MsAHYAB49zni9X1XaAJPcAPw38zRivfS1wZVV9D6CqHuo7d01VPQXck+Sl7ViAjyY5EXgKOBDYee6vqur29vpo4Jad4yW5ou++TgUOTbJznv2S7FtVD/c3lmQxsBhgxn5zx3g7kiRJU8N0DsEZXALAEuABeivGe9BbbR2PJ/pe72B8zzRAjWHcnffyDmAu8Oqq+lGSrcBe7dyjI9SPZA/gmKr64a4aq6oVwAqAWfPmj9ajJEnSlDSd9gQ/DOzb9341sCjJjCRzgROBO0eomw3c31Zd3wnM2E39/CjJngNqvgy8JclPAgzbDjGS2cB3WwA+hd6q80juBE5K8qIkM4Ez+s7dALx355u2Ai5JktQp0yYEV9WDwK3tg3DLgauBTfT2wt4InF9V32nHnmwfRFsCXAKcleR2elsGHh15hnFbAWza1Qfjqupu4A+AW5JsBP7LgDEvBxYmWUtvVfjro4y7DfgocAfwJeAeYHs7fW4bY1PbvvGesd+SJEnS9JAqf9M9HSXZp6oeaSvBVwOfqqqrn8lYs+bNr3lnXbR7G+wQ/9lkSZKeP0nWVdXALzmYNivBepoLkmwAtgD3AddMcD+SJEmTxnT+YFynVdV5E92DJEnSZGUI1kBHHDibtf5KX5IkTSNuh5AkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnzJzoBjT5bd62naGl1010G9LTbF122kS3IEmaolwJliRJUucYgiVJktQ5hmBJkiR1zpQLwUnmJDlnDHVDSd4+xrotIxw/IMmVY7j+A8PePzLoml2M9ctJlj6L69+fZO9ner0kSVJXTLkQDMwBBoZgYAgYGIJHU1Xfrqozx1D6gcElY57z2qpa9iyGeD9gCJYkSRpgKobgZcBBSTYkWZ6e5Um2JNmcZFFf3Qmtbklb8f1KkvXt59hdTdK/Qpzk7CSfSfKFJN9K8p/b8WXAC9oclw8Y6+tJLmt9Xp7k1CS3tvGO7pvn4vZ6ZZJPJPlaknuTnNmOn5zkc31jX9yuOxc4ALgpyU3t3OuT3Nbu94ok++zsO8k9STYl+dgz+UOQJEmayqbiV6QtBQ6vqgUASc4AFgBHAvsDa5KsbnXnVdXprW5v4HVV9XiS+cAqYOE45l0AvBJ4AvhGkk9W1dIk793ZywA/C7wZWAysobdKfTzwy/RWk984wjXzWs0hwLXAqNszquoTSX4LOKWqvpdkf+CDwKlV9WiSfw/8VgvZbwIOqapKMmdMdy9JkjSNTMUQPNzxwKqq2gE8kOQW4CjgB8Pq9gQuTrIA2AEcPM55vlxV2wGS3AP8NPA347j+vqra3K6/u41XSTbT27oxkmuq6ingniQvHWe/rwEOBW5NAvATwG30nsvjwGVJrgM+N9LFSRbTC+zM2G/uOKeWJEma3KZDCM4Y65YAD9BbMd6DXhAcjyf6Xu9g/M+u//qn+t4/tYux+q/ZeZ9P8uPbWPYa5doAX6yqtz3tRG/7xb8A3gq8F3jt8JqqWgGsAJg1b36NMockSdKUNBX3BD8M7Nv3fjWwKMmMJHOBE4E7R6ibDdzfVlbfCczYTf38KMmeu2mssfgr4NAks5LMphdmd+q/59uB45L8LPS2gyQ5uO0Lnl1Vf0Hvg3Rj2cohSZI0rUy5leCqerB9oGwL8HngfOAYYCNQwPlV9Z0kDwJPJtkIrAQuAa5K8mbgJuDR3dTSCmBTkvVV9Y7dNOaoqupvkvwZsAn4FnDXsF4+n+T+qjolydnAqiSz2vkP0gvKf55kL3qrxUue654lSZImm1T5m27t2qx582veWRdNdBvS02xddtpEtyBJmmSSrKuqgV9+MBW3Q0iSJEnPiiFYkiRJnTPl9gTr+XfEgbNZ66+dJUnSNOJKsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjpn5kQ3oMlv87btDC29bqLbkJ61rctOm+gWJEmThCvBkiRJ6hxDsCRJkjrHECxJkqTOmfIhOMmcJOeMoW4oydvHWLdl93T3zCS5IMl5E9mDJEnSdDblQzAwBxgYgoEhYGAIng6SzJjoHiRJkiaz6RCClwEHJdmQZHl6lifZkmRzkkV9dSe0uiVtxfcrSda3n2MHTZTk3yVZk2RTko+0Yxf2r0S3VdzfHq1+hDHf0ObfmOTLfacOTXJzknuTnNtXf02SdUnuTrK47/gjSf5jkjuAY5L8UpKvJ/lqkk8k+Vyre2GST7W+7kryK2N+0pIkSdPEdPiKtKXA4VW1ACDJGcAC4Ehgf2BNktWt7ryqOr3V7Q28rqoeTzIfWAUsHG2SJK8H5gNHAwGuTXIi8GngIuCSVvoW4A2j1VfV6r4x5wKXAidW1X1JXtw35SHAKcC+wDeS/FFV/Qh4V1U9lOQF7d6uqqoHgRcCW6rqw0n2Ar7VN+6qvnF/B7ixqt6VZA5wZ5IvVdWjw+53MbAYYMZ+c3fx+CVJkqae6bASPNzxwKqq2lFVDwC3AEeNULcncGmSzcAVwKEDxn19+7kLWE8vpM6vqruAlyQ5IMmRwPer6q9Hqx825muA1VV1H0BVPdR37rqqeqKqvgd8F3hpO35uko3A7cDL+sbcAVzVXh8C3LtzXHoBv/8+libZANwM7AX88+E3W1UrqmphVS2csffsAY9GkiRpapkOK8HDZYx1S4AH6K0Y7wE8PoZx/1NV/fEI564EzgR+it7K8KD6/jFrlHNP9L3eAcxMcjJwKnBMVT2W5GZ6IRbg8ara0TfuruY8o6q+sYsaSZKkaW06rAQ/TG/LwE6rgUVJZrTtBicCd45QNxu4v6qeAt4JDPow2fXAu5LsA5DkwCQvaec+DbyVXhC+cgz1O90GnJTk5a3mxezabHorzY8lOYTeSvJIvg78TJKh9n5R37nrgfclSZvzlQPmlCRJmnam/EpwVT2Y5Nb2tWafB84HjgE20ltlPb+qvpPkQeDJtpVgJb09vFcleTNwE/DoiBP80zw3JPl54LaWHx8BfhX4blXdnWRfYFtV3T+ovm/Mv2t7bz+TZI927nW7aOMLwHuSbAK+QW9LxEi9/rB9WO8LSb5H7y8BO/0evT3Mm1oQ3gqcvqt7lyRJmm5SNdpv4zWVJdmnqh5pQfcPgW9V1cefyViz5s2veWddtHsblCbA1mWnTXQLkqTnWJJ1VTXqlx3sNB22Q2hkv9k+/HY3vW0Uu9qbLEmS1CmuBGughQsX1tq1aye6DUmSpIFcCZYkSZJGYQiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS58yc6AY0+W3etp2hpddNdBvSbrN12WkT3YIkaYK5EixJkqTOMQRLkiSpcyYsBCe5OcnCiZp/LJL8cpKl7fUFSc6b6J4kSZL07E3JPcFJZlbVk8/1PFV1LXDtcz2PJEmSnl+7XAlOMpTkL5NcmuTuJDckeUE7948ruUn2T7K1vT47yTVJPpvkviTvTfJbSe5KcnuSF/dN8atJvpZkS5Kj2/UvTPKpJGvaNb/SN+4VST4L3DCszwuTnNP3/oIkv53k5CS3JPmzJN9MsizJO5LcmWRzkoNa/b9Kckeb70tJXto358UDntHKJH+U5KYk9yY5qfX/l0lW9tW9PsltSda3+9inHV+W5J4km5J8rB17c3smG5Os7vuz+Eq7fn2SY9vxPZJc0v58PpfkL5Kc2c69ut3/uiTXJ5nXjp/bN+end3V/kiRJ09FYtkPMB/6wqg4D/h44YwzXHA68HTga+APgsap6JXAb8Gt9dS+sqmOBc4BPtWO/A9xYVUcBpwDLk7ywnTsGOKuqXjtsvk8Di/revwW4or0+Evi3wBHAO4GDq+po4DLgfa3mq8BrWo+fBs4fwz32exHwWmAJ8Fng48BhwBFJFiTZH/ggcGpVvQpYC/xW+wvBm4DDquoVwO+38T4M/MuqOhL45Xbsu8Dr2vWLgE+04/8aGGr39xvtGZFkT+CTwJlV9Wp6z/cP2jVLgVe2Od8zznuVJEma8sayHeK+qtrQXq+jF7gGuamqHgYeTrKdXjAE2Ay8oq9uFUBVrU6yX5I5wOuBX+7bf7sX8M/b6y9W1UPDJ6uqu5K8JMkBwFzg+1X110l+BlhTVfcDJPk//NMq8mZ6IRvgnwF/2lZKfwK4bwz32O+zVVVJNgMPVNXmNt/d9J7XPwMOBW5NQpvjNuAHwOPAZUmuAz7XxrsVWJnkz4DPtGN7AhcnWQDsAA5ux48Hrqiqp4DvJLmpHf85en8Z+WKbcwZwfzu3Cbg8yTXANSPdUJLFwGKAGfvNHefjkCRJmtzGEoKf6Hu9A3hBe/0k/7SSvNcurnmq7/1Tw+asYdcVEOCMqvpG/4kkvwA8uos+rwTOBH6K3mrueHr5JPBfquraJCcDF+xinpH0jzl8vpn0ntsXq+ptwy9s20D+BfBW4L3Aa6vqPe1+TwM2tOD7PuABeivbe9ALz9B7XiMJcHdVHTPCudOAE+mtMn8oyWHD91hX1QpgBcCsefOH/zlJkiRNac/m2yG2Aq9ur898hmMsAkhyPLC9qrYD1wPvS1u+TPLKMY71aXpB8kx6gXg8ZgPb2uuzxnntWNwOHJfkZwGS7J3k4LYveHZV/QXwfmBBO39QVd1RVR8Gvge8rPV4f1vxfSe9lV3obeU4o+0Nfilwcjv+DWBukn/cHpHksCR7AC+rqpvobfuYA+zzHNyzJEnSpPVsvh3iY8CfJXkncOMzHOP7Sb4G7Ae8qx37PeAiYFMLwluB0wcNVFV3J9kX2LZz+8M4XABckWQbvcD68nFeP6i3v0tyNrAqyax2+IPAw8CfJ9mL3srtknZueZL57diXgY3AJcBVSd4M3MQ/rYpfRW8leQvwTeAOen+h+If2AblPJJlN78/6olbzv9qxAB+vqr/fnfcrSZI02aXK33RPdUn2qapHkvwkcCdwXFV9Z3eNP2ve/Jp31kW7azhpwvnPJkvS9JVkXVUN/LcopuT3BOtpPtc+VPgTwO/tzgAsSZI0HRmCp4GqOnmie5AkSZpKDMEa6IgDZ7PWXx9LkqRp5Nl8O4QkSZI0JRmCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS58yc6AY0+W3etp2hpddNdBuSnoGty06b6BYkaVJyJViSJEmdYwiWJElS5xiCJUmS1DlTJgQnmZPknDHUDSV5+xjrtuye7naPJAuTfOJZXH92kgN2Z0+SJEnT0ZQJwcAcYGAIBoaAgSF4MqqqtVV17rMY4mzAECxJkjTAVArBy4CDkmxIsjw9y5NsSbI5yaK+uhNa3ZK24vuVJOvbz7GDJkry75KsSbIpyUfasQv7V6KTXJDkt0erH2HMR9oY65J8Kfm/7d17uF1Vee/x748AQQQTFbARtUEatAIaJFCRi+BBaguKHtBQraK0B1uPpWIppWqVemobD+0BlaqNVqmKwAGFojwWvHATRZJwSYCKKOY5AhELCnKRCOE9f6yxdbnZO3vlurP2/H6eZz1rrjHfOcaYY8+VvHusMdfO3kkuS3Jbkle2mAOTfKmv/k/2xRzXyn9tBjvJCS32SGAecGY79yck2TPJ5a3Ni5PMasccl+Tm1t+z1/gnIUmSNOSG6SvSTgJ2q6q5AEmOAOYCLwC2AxYluaLFnVBVh7W4rYGXVdXDSeYAZ9FLFseU5BBgDrA3EODCJAcAZwOnAR9poa8FXj5efFVdMarqJwKXVdVfJTkf+DvgZcDzgH8DLhyjO88FDgK2BW5J8tHx+l1V5yV5Wzv3xUm2AD4MHF5V/9V+SXg/cEwbo52qamWSmeOMw7HAsQDTnrT9eM1KkiQNpWFKgkfbDzirqlYBdyW5HNgL+NmouC2A05PMBVYBu0xQ7yHtcV17vQ0wp6r+NckObc3t9sBPq+r/tRnax8UDo5PgXwD/0baXASur6pEky+gt4RjLRVW1EliZ5MfA0yboe7/nALsBX0kCMA1Y0fYtpTdjfAFwwVgHV9VCYCHA9Flzag3alSRJ2uQNcxKcAeOOB+6iN2O8GfDwAPX+Q1X9yxj7zgOOBH6D3szwRPH9HqmqkWTyMWAlQFU9lmS8n8PKvu1V9H5ej/Lry1i2Ws153FRV+4yx71DgAOCVwN8k2bWqHp2g/5IkSVPGMK0Jvp/esoARVwDzk0xLsj29pO6aMeJmACuq6jHgDfRmRFfnYuCYJNsAJNkxyQ5t39nAUfQS4fMGiN8Q7gJ2SPLUJNOBw/r29Z/7LcD2SfZp/doiya5JNgOeWVWXAifSu+Fwmw3YX0mSpE3O0MwEV9U9Sa5qN4V9mV4Ctw9wA1DAiVX1oyT3AI8muQE4g94a3s8neQ1wKfDgBO1ckuS3gW+1ZQQPAH8I/LiqbkqyLXBHVa2YKH79jsAv+/dIkvcB3wZ+AHynb/cZwMeS/Jze2BwJfCjJDHo/69OA7wKfbWUBTq2qezdEXyVJkjZV+dUn9NLYps+aU7OOPm2yuyFpLSxfcOhkd0GSNqokS6pq3C9BGDFMyyEkSZKk9cIkWJIkSZ0zNGuCNXl233EGi/1IVZIkTSHOBEuSJKlzTIIlSZLUOSbBkiRJ6hyTYEmSJHWOSbAkSZI6xyRYkiRJnWMSLEmSpM4xCZYkSVLnmARLkiSpc0yCJUmS1DkmwZIkSeock2BJkiR1jkmwJEmSOmfzye6ANn3L7riP2SddNNndkDRFLV9w6GR3QVIHORMsSZKkzjEJliRJUueYBEuSJKlzhiYJTvLNAWLenmTrjdCX2Ule1/d6XpIPbYB2lifZbg3iz0hy5PruhyRJ0lQzNElwVb14gLC3A2uUBCeZthbdmQ38MgmuqsVVddxa1CNJkqRJMDRJcJIH2vOBSS5Lcl6S7yQ5Mz3HAU8HLk1yaYs9JMm3klyb5Nwk27Ty5Unek+QbwGtafR9Ick2S7ybZv8XNTnJlO/7aJCOJ+AJg/yTXJzm+9elL7ZinJLkgydIkVyd5fis/OcknW1u3tf6OnNsFSZYkuSnJsYOMRZJ/an36WpLtx4h5T5JFSW5MsjBJWvmY5ypJktQlQ5MEj7IHvVnf5wHPBvatqg8BdwIHVdVBbRnBu4GDq+qFwGLgHX11PFxV+1XV2e315lW1d6v3va3sx8DL2vHzgZElDycBV1bV3Ko6dVTf/ha4rqqeD7wT+HTfvucCvwvsDbw3yRat/Jiq2hOYBxyX5KkTnP8TgWtbvy7v62+/06tqr6raDXgCcFjfvrHO9dckOTbJ4iSLVz103wTdkSRJGi7D+j3B11TV7QBJrqe3POEbo2JeRC9JvqpNgm4JfKtv/zmj4r/Qnpe0+gC2AE5PMhdYBewyQN/2A44AqKqvJ3lqkhlt30VVtRJYmeTHwNOA2+klvq9uMc8E5gD3rKaNx/r6/9m+vvc7KMmJ9JaHPAW4Cfjias7111TVQmAhwPRZc2o1fZEkSRo6w5oEr+zbXsXY5xHgK1X1B+PU8eA4dfbXdzxwF/ACerPmDw/Qt4xRNpJEPq7fSQ4EDgb2qaqHklwGbDVAO2PV3+tAshXwEWBeVf0wycmj6hzrXCVJkjpjWJdDjOd+YNu2fTWwb5LfAkiydZJBZnL7zQBWVNVjwBuAkZvo+tsZ7Qrg9a3NA4G7q+pnE7Tx05YAP5feDPZENgNGvgXidTx+Fnwk4b27rYP2GyMkSZL6TLVZwIXAl5OsaOuC3wSclWR62/9u4LtrUN9HgM8neQ1wKb+aPV4KPJrkBuAM4Lq+Y04GPpVkKfAQcPQEbfwH8Cct/hZ6yftEHgR2TbIEuI/eeuVfqqp7k3wcWAYsBxYNUKckSVJnpMrlnsMmyQNVtc3Gam/6rDk16+jTNlZzkjpm+YJDJ7sLkqaQJEuqat5EcVNtOYQkSZI0oam2HKITNuYsMMDuO85gsTM1kiRpCnEmWJIkSZ1jEixJkqTOMQmWJElS55gES5IkqXNMgiVJktQ5JsGSJEnqHJNgSZIkdY5JsCRJkjrHJFiSJEmdYxIsSZKkzjEJliRJUueYBEuSJKlzTIIlSZLUOSbBkiRJ6pzNJ7sD2vQtu+M+Zp900WR3Q5I2KcsXHDrZXZC0DpwJliRJUueYBEuSJKlzhj4JTjIzyVsHiJud5HUDxt04QNwZSY4ctJ9rIsmBSb60IeqWJEnSFEiCgZnAhEkwMBuYMAmeCpK41luSJGk1pkISvADYOcn1SU5JzylJbkyyLMn8vrj9W9zxbcb3yiTXtseLV9dIq/f0JDcnuQjYoW/fe5Isam0ubLE7J7m2L2ZOkiVj1PtbSb6a5IbWj53brm2SnJfkO0nOTJLx2mrllyX5+ySXA3/e2r+6xb4vyQN9bf5lK1+a5G/XbtglSZKG11RIgk8Cvl9Vc6vqL4H/DswFXgAcDJySZFaLu7LFnQr8GHhZVb0QmA98aIJ2Xg08B9gd+B9Af9J8elXtVVW7AU8ADquq7wP3JZnbYt4MnDFGvWcC/1xVL2h1rmjlewBvB54HPBvYd7y2+uqaWVUvqap/Aj4IfLCq9gLuHAlIcggwB9i7jdOeSQ6Y4NwlSZKmlKmQBI+2H3BWVa2qqruAy4G9xojbAvh4kmXAufSSzdU5oK/eO4Gv9+07KMm3W10vBXZt5Z8A3pxkGr1E+3P9FSbZFtixqs4HqKqHq+qhtvuaqrq9qh4Drqe3nGN1bQGc07e9TzsvRrV7SHtcB1wLPJdeUvxrkhybZHGSxaseum+1AyNJkjRspuLa0QwYdzxwF70Z482Ahwc4ph7XWLIV8BFgXlX9MMnJwFZt9+eB99JLmJdU1T1r0NeVfdurgM0naAvgwQHOIcA/VNW/rC6oqhYCCwGmz5rzuPOWJEkaZlNhJvh+YNu+11cA85NMS7I9vRnca8aImwGsaDOtbwCmTdDOFcBRrd5ZwEGtfCQJvTvJNsAvvzGiqh4GLgY+CnxqdIVV9TPg9iSvAkgyPcnWq+nDuG2N4WrgiLZ9VF/5xcAx7XiS7Jhkh9EHS5IkTWVDnwS32dWr2o1ipwDnA0uBG+jNwJ5YVT9qZY+2G9COpzejenSSq4FdmHgW9XzgVmAZvaT28tb+vcDHW/kFwKJRx51Jbwb5knHqfQNwXJKlwDeB31jNuU7UVr+3A+9Icg0wC7iv1XEJveUR32pLKs7j1385kCRJmvJS5SfdG1KSE4AZVfU3G7ndrYGfV1UlOQr4g6o6fG3qmj5rTs06+rT120FJGnL+2WRp05RkSVXNmyhuKq4J3mQkOR/Ymd4NbBvbnsDp7SvU7gWOmYQ+SJIkbZJMgjegqnr1JLZ9Jb2b/iRJkjSKSbAmtPuOM1jsx36SJGkKGfob4yRJkqQ1ZRIsSZKkzjEJliRJUueYBEuSJKlzTIIlSZLUOSbBkiRJ6hyTYEmSJHWOSbAkSZI6xyRYkiRJnWMSLEmSpM4xCZYkSVLnmARLkiSpc0yCJUmS1DmbT3YHtOlbdsd9zD7posnuhiRtcpYvOHSyuyBpLTkTLEmSpM4xCZYkSVLnmARLkiSpczqbBCeZmeStA8TNTvK6AeNuHKP86UnOG+D4d456/cBExwxQ55uSnN62T05ywrrWKUmSNBV0NgkGZgITJsHAbGDCJHg8VXVnVR05QOg7Jw6RJEnS+tDlJHgBsHOS65Ockp5TktyYZFmS+X1x+7e449uM75VJrm2PF6+ukf4Z4jYz+4Uk/5Hk1iT/u5UvAJ7Q2jhzgvremGRpkhuSfKaVvSLJt59Ffz8AABIRSURBVJNcl+SrSZ42QR3HJbm51XP2YMMlSZI0dXT5K9JOAnarqrkASY4A5gIvALYDFiW5osWdUFWHtbitgZdV1cNJ5gBnAfPWoN25wB7ASuCWJB+uqpOSvG2kL+NJsivwLmDfqro7yVParm8AL6qqSvLHwInAX0xw7jtV1cokM8dp61jgWIBpT9p+DU5PkiRp09flJHi0/YCzqmoVcFeSy4G9gJ+NitsCOD3JXGAVsMsatvO1qroPIMnNwG8CPxzw2JcC51XV3QBV9ZNW/gzgnCSzgC2BH0xQz1LgzCQXABeMFVBVC4GFANNnzakB+ydJkjQUurwcYrQMGHc8cBe9GeN59JLONbGyb3sVa/aLSICxEtIPA6dX1e7AW4CtJqjnUOCfgT2BJUn8ZUiSJHVKl5Pg+4Ft+15fAcxPMi3J9sABwDVjxM0AVlTVY8AbgGnrqT+PJNligpivAa9N8lSAvuUQM4A72vbRq6sgyWbAM6vqUnrLJmYC26x1ryVJkoZQZ2cAq+qeJFe1m9a+TC8h3Ae4gd5s64lV9aMk9wCPJrkBOAP4CPD5JK8BLgUeXE9dWggsTXJtVb1+nD7flOT9wOVJVgHXAW8CTgbOTXIHcDWw02ramQZ8NskMejPLp1bVvevpHCRJkoZCqlzuqdWbPmtOzTr6tMnuhiRtcpYvOHSyuyBplCRLqmrCLy3o8nIISZIkdVRnl0NocLvvOIPFznZIkqQpxJlgSZIkdY5JsCRJkjrHJFiSJEmdYxIsSZKkzjEJliRJUueYBEuSJKlzTIIlSZLUOSbBkiRJ6hyTYEmSJHWOSbAkSZI6xyRYkiRJnWMSLEmSpM4xCZYkSVLnmARLkiSpczaf7A5o07fsjvuYfdJFk90NSZI6a/mCQye7C1OOM8GSJEnqHJNgSZIkdc4mlwQneedk92FDSPK+JAdv5DbflOT0tn1ykhM2ZvuSJEmbqk0uCQY2ahKcZL2ti15dXVX1nqr66vpqS5IkSWtvvSbBSd6YZGmSG5J8ppWdkeTIvpgH2vOsJFckuT7JjUn2T7IAeEIrO7PFvaPtvzHJ21vZ7CTfSfKJVn5mkoOTXJXk1iR7t7gnJvlkkkVJrktyeCt/U5Jzk3wRuGTUOTwxyUXtHG5MMr+V75nk8iRLklycZFYrvyzJ3ye5HHhXkuVJNmv7tk7ywyRb9I9Dkr2SfLO1cU2SbZNMS3JK6+vSJG9ZgzF+RZJvt3P8apKnTfBzOi7Jza2es9fohyxJkjQFrM9Z0F2BdwH7VtXdSZ4ywSGvAy6uqvcnmQZsXVVXJnlbVc1tde4JvBn4HSDAt1uy+VPgt4DXAMcCi1p9+wGvpDeb/KrWn69X1TFJZgLXJBmZjd0HeH5V/WRUv14O3FlVh7Y+zEiyBfBh4PCq+q+WGL8fOKYdM7OqXtLiXwi8BLgUeEU7x0eSjIzTlsA5wPyqWpTkScDPgT8C7quqvZJMB65KcklV/WCAMf4G8KKqqiR/DJwI/MVqxv4kYKeqWtnGRZIkqVPW51ekvRQ4r6ruBhgjuRxtEfDJlmBeUFXXjxGzH3B+VT0IkOQLwP7AhcAPqmpZK78J+FpLApcBs9vxhwCv7FsLuxXwrLb9lXH6uAz4xyQfAL7UEvPdgN2Ar7Rkdhqwou+Yc0Ztz6eXBB8FfGRU/c8BVlTVIoCq+lk7h0OA5/fNms8A5gA/6Dt2vDF+BnBOm53ectQxY1kKnJnkAuCCsQKSHEvvFwymPWn7CaqTJEkaLutzOUSAGqP80ZF20ssgtwSoqiuAA4A7gM8keeM4dY5nZd/2Y32vH+NXyX2AI6pqbns8q6r+s+17cKxKq+q7wJ70kuF/SPKeVs9NffXsXlWH9B3WX9eFwO+1Wdo9ga+PcU5jjVOAP+trY6equmTAYz8MnF5VuwNvoZfsr86hwD+3/i0Zay1zVS2sqnlVNW/a1jMmqE6SJGm4rM8k+GvAa5M8FaDvo/rl9JItgMOBLdr+3wR+XFUfB/4VeGGLeaTNDgNcAbyqra19IvBq4Mo16NPFwJ+15Jske0x0QJKnAw9V1WeBf2z9ugXYPsk+LWaLtjThcarqAeAa4IP0ZpJXjQr5DvD0JHu1urZtSejFwJ+OnHuSXdo59xtvjGfQ+2UC4OgJzm8z4JlVdSm9ZRMzgW1Wd4wkSdJUs96WQ1TVTUneD1yeZBVwHfAm4OPAvye5hl4SNzJreiDwl0keAR4ARmaCFwJLk1xbVa9Pcga9pBLgE1V1XZLZA3brfwGntfpCLyE/bIJjdgdOSfIY8Ajwp1X1i7ZM4UNJZtAbt9OAm8ap4xzg3HaOv6bVNR/4cJIn0FsPfDDwCXrLOK5tff0veuua+48db4xPBs5NcgdwNbDTas5vGvDZdh4BTq2qe1c7IpIkSVNMqsb6dF36lemz5tSso0+b7G5IktRZ/tnkwSVZUlXzJorbFL8nWJIkSdqgTIIlSZLUOevzK9I0Re2+4wwW+zGMJEmaQpwJliRJUueYBEuSJKlzTIIlSZLUOSbBkiRJ6hyTYEmSJHWOSbAkSZI6xyRYkiRJnWMSLEmSpM4xCZYkSVLnmARLkiSpc0yCJUmS1DkmwZIkSeock2BJkiR1zuaT3QFt+pbdcR+zT7posrshSZKG1PIFh052Fx7HmWBJkiR1jkmwJEmSOsckWJIkSZ0zNElwkplJ3jpA3Owkrxsw7sYB4s5IcuSg/VxXSb65DscemOTF67M/kiRJU9HQJMHATGDCJBiYDUyYBG+qqmpdktgDAZNgSZKkCQxTErwA2DnJ9UlOSc8pSW5MsizJ/L64/Vvc8W3G98ok17bHapPEVu/pSW5OchGwQ9++9yRZ1Npc2GJ3TnJtX8ycJEvGqPeyJKcmuSLJfybZK8kXktya5O/64h5ozwe2Y85L8p0kZyZJ27c8yXZte16Lmw38CXB8O/f9k2yf5POtz4uS7NuOeUmLuT7JdUm2XZsfiCRJ0rAapq9IOwnYrarmAiQ5ApgLvADYDliU5IoWd0JVHdbitgZeVlUPJ5kDnAXMW007rwaeA+wOPA24Gfhk23d6Vb2v1fsZ4LCq+mKS+5LMrarrgTcDZ4xT9y+q6oAkfw78O7An8BPg+0lOrap7RsXvAewK3AlcBewLfGOsiqtqeZKPAQ9U1T+2Pn4OOLWqvpHkWcDFwG8DJwD/s6quSrIN8PDo+pIcCxwLMO1J269muCRJkobPMM0Ej7YfcFZVraqqu4DLgb3GiNsC+HiSZcC5wPMmqPeAvnrvBL7et++gJN9udb2UXoIK8AngzUmmAfOBz41T94XteRlwU1WtqKqVwG3AM8eIv6aqbq+qx4Dr6S31WBMHA6cnub61/aQ263sV8H+SHAfMrKpHRx9YVQural5VzZu29Yw1bFaSJGnTNkwzwaNlwLjjgbvozRhvxhiznmOoxzWWbAV8BJhXVT9McjKwVdv9eeC99BLmJWPM6I5Y2Z4f69seeT3Wz6I/ZlVfzKP86heYrRjfZsA+VfXzUeUL2lKP3weuTnJwVX1nNfVIkiRNKcM0E3w/0L929QpgfpJpSbanN4N7zRhxM4AVbTb1DcC0Cdq5Ajiq1TsLOKiVjySbd7clBL/8xoiqepjeUoOPAp9am5NbQ8vpLaUAOKKvfPS5XwK8beRFkpGlJDtX1bKq+gCwGHjuBu2tJEnSJmZokuA2u3pVuyntFOB8YClwA70Z2BOr6ket7NEkNyQ5nt7s7dFJrgZ2AR6coKnzgVvpLVn4KL1lFlTVvcDHW/kFwKJRx51Jbwb5knU91wH8LfDBJFfSmyEe8UXg1SM3xgHHAfOSLE1yM70b5wDe3sbxBuDnwJc3Qp8lSZI2Gal63Cf/WgtJTgBmVNXfTHZf1rfps+bUrKNPm+xuSJKkIbV8waEbra0kS6pqdV+CAAz3muBNRpLzgZ3p3SwnSZKkTZxJ8HpQVa+e7D5IkiRpcCbBmtDuO85g8Ub8GEOSJGlDG5ob4yRJkqT1xSRYkiRJnWMSLEmSpM4xCZYkSVLnmARLkiSpc0yCJUmS1Dn+xThNKMn9wC2T3Y8hsB1w92R3Ygg4ToNxnAbjOA3GcRqM4zSYTX2cfrOqtp8oyO8J1iBuGeTPD3ZdksWO08Qcp8E4ToNxnAbjOA3GcRrMVBknl0NIkiSpc0yCJUmS1DkmwRrEwsnuwJBwnAbjOA3GcRqM4zQYx2kwjtNgpsQ4eWOcJEmSOseZYEmSJHWOSXDHJHl5kluSfC/JSWPsn57knLb/20lm9+3761Z+S5LfHbTOYbS245TkZUmWJFnWnl/ad8xlrc7r22OHjXdGG8Y6jNPsJD/vG4uP9R2zZxu/7yX5UJJsvDPaMNZhnF7fN0bXJ3ksydy2r4vX0wFJrk3yaJIjR+07Osmt7XF0X3kXr6cxxynJ3CTfSnJTkqVJ5vftOyPJD/qup7kb63w2lHW8nlb1jcWFfeU7tffore09u+XGOJcNaR2up4NG/fv0cJJXtX3DcT1VlY+OPIBpwPeBZwNbAjcAzxsV81bgY237KOCctv28Fj8d2KnVM22QOoftsY7jtAfw9La9G3BH3zGXAfMm+/w2kXGaDdw4Tr3XAPsAAb4M/N5kn+tkjdOomN2B2zp+Pc0Gng98Gjiyr/wpwG3t+clt+8kdvp7GG6ddgDlt++nACmBme31Gf+ywP9ZlnNq+B8ap9/8CR7XtjwF/OtnnOpnj1BfzFOAnwNbDdD05E9wtewPfq6rbquoXwNnA4aNiDgf+rW2fB/y3NnNyOHB2Va2sqh8A32v1DVLnsFnrcaqq66rqzlZ+E7BVkukbpdcb37pcT2NKMgt4UlV9q3r/kn4aeNX67/pGtb7G6Q+AszZoTyfXhONUVcurainw2Khjfxf4SlX9pKp+CnwFeHlXr6fxxqmqvltVt7btO4EfAxP+QYEhtS7X05jae/Kl9N6j0HvPdvZ6GuVI4MtV9dCG6+r6ZxLcLTsCP+x7fXsrGzOmqh4F7gOeuppjB6lz2KzLOPU7Ariuqlb2lX2qfTT0N1PgY9l1HaedklyX5PIk+/fF3z5BncNmfV1P83l8Ety162lNj+3q9TShJHvTm/n7fl/x+9syiVOnwC/v6zpOWyVZnOTqkY/46b0n723v0bWpc1O0vv4PP4rH//u0yV9PJsHdMtZ/kqO/HmS8mDUtH2brMk69ncmuwAeAt/Ttf31V7Q7s3x5vWMd+TrZ1GacVwLOqag/gHcDnkjxpwDqHzfq4nn4HeKiqbuzb38XraU2P7er1tPoKejPknwHeXFUjs3t/DTwX2IveR9t/tS6d3ASs6zg9q3p/Ee11wGlJdl4PdW6K1tf1tDtwcV/xUFxPJsHdcjvwzL7XzwDuHC8myebADHrrfMY7dpA6h826jBNJngGcD7yxqn45y1JVd7Tn+4HP0fsYapit9Ti1ZTX3AFTVEnqzUbu0+GdMUOewWafrqXncLEtHr6c1Pbar19O42i+bFwHvrqqrR8qrakX1rAQ+Rbevp5HlIlTVbfTW3+8B3A3MbO/RNa5zE7U+/g9/LXB+VT0yUjAs15NJcLcsAua0u1u3pPcf64WjYi4ERu6sPhL4eltLdyFwVHp3se8EzKF3w8kgdQ6btR6nJDPp/Qfz11V11Uhwks2TbNe2twAOA25kuK3LOG2fZBpAkmfTu55uq6oVwP1JXtQ+3n8j8O8b42Q2oHV535FkM+A19Nbq0cq6ej2N52LgkCRPTvJk4BDg4g5fT2Nq8ecDn66qc0ftm9WeQ2+da2evp3YdTW/b2wH7Aje39+Sl9N6j0HvPdvZ66vO4+xWG5nqa7DvzfGzcB/D7wHfpzby9q5W9D3hl294KOJfejW/XAM/uO/Zd7bhb6LvDeqw6h/2xtuMEvBt4ELi+77ED8ERgCbCU3g1zHwSmTfZ5TuI4HdHG4QbgWuAVfXXOo/cP5veB02l/1GeYH+v4vjsQuHpUfV29nvaiN3P1IHAPcFPfsce08fsevY/5u3w9jTlOwB8Cj4z692lu2/d1YFkbq88C20z2eU7iOL24jcUN7fmP+up8dnuPfq+9Z6dP9nlO1ji1fbOBO4DNRtU5FNeTfzFOkiRJneNyCEmSJHWOSbAkSZI6xyRYkiRJnWMSLEmSpM4xCZYkSVLnmARLkiSpc0yCJUmS1DkmwZIkSeqc/w9b5N8kzt0yHAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsEAAAJCCAYAAAAhlRoCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xu4nWV95//3h4QGEUi0RBsY21gaihwkSqByBgetLUxbBzQeaqHa5ufwU8e0DJOxaunJCY2/kVFK28DPZg40VkAoShU8AFEEciInqIdrID1ERAUaOQiV8J0/1p12udk7a28I7MPzfl3Xvljreb7PfX+fFf745N73s5KqQpIkSeqSPca7AUmSJOm5ZgiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdM328G9DEt//++9fcuXPHuw1JkqSB1q1b972qmj2ozhCsgebOncvatWvHuw1JkqSBkvzdaOrcDiFJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRroM3bto93C5IkSbuVIViSJEmdYwiWJElS5xiCJUmS1DmG4A5Ick6Si8e7D0mSpInCEPwcSTJtvHuQJElSjyF4N0hyTZJ1Se5Msqjv+MNJfj/J7cCxSY5KcnOrvT7JnFb3m0nWJNmY5Kokew8zxz5J/iLJ5iSbkpzZjr+5HduS5MK++l9P8o0kNwPH9x2f3eZY036OHzqXJEnSVJeqGu8eJr0kL6yqB5I8D1gDnFxV9ycpYGFVfTLJnsDNwC9X1XeTLAR+vqrenuTHq+r+NtYfAvdV1ceGzHEhMKOq3tvevwB4HnAbcBTwIHAD8FHg9vZzFLAduBG4o6releQvgUuq6itJfhK4vqpetqv7mzFnXj1+7zd3x0clSZL0rEqyrqoWDKqb/lw00wHvSfL69volwDzgfmAHcFU7/rPA4cDnkwBMA+5t5w5v4XcWsA9w/TBznAa8aeebqnowyUnATVX1XYAklwMntZL+438FHNw3zqGtB4D9kuxbVQ/1T9ZWtBcBTNtv9ug/CUmSpEnAEPwMJTmFXrA8tqoeTXITsFc7/VhV7dhZCtxZVccOM8wK4FeqamOSc4BThpsKGLpsn2HqdhppiX+P1usPdnEtVbUcWA69leBd1UqSJE027gl+5mYCD7YAfAjwqhHqvg7MTnIsQJI9kxzWzu0L3Nu2TLx1hOtvAN61803bDnE7cHKS/duDd2+mt+XiduCUJD/exnzDLsaZP7bblSRJmvwMwc/c54DpSTYBf0Bvj+5TVNU/A2cBFybZCGwAjmunP0AvuH4e+NoI8/wh8IL2ANxG4NSquhf4L/T2/G4E1lfVX7fjFwC3Al8A1veN8x5gQXu47i7gnU/vtiVJkiYvH4zTQD4YJ0mSJovRPhjnSrAkSZI6xxAsSZKkzjEEa6AjDpw53i1IkiTtVoZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWANt3raduUuuG+82JEmSdhtDsCRJkjrHECxJkqTOMQRLkiSpc6ZcCE4yK8m5o6ibm+Qto6zbMsYeLkty6ICaFUnOerp9jbKPC5Kct6v5JEmSumjKhWBgFjAwBANzgd0SNoeqqt+oqrue5uVzeZb6kiRJUs9UDMFLgYOSbEiyLD3LkmxJsjnJwr66E1vd4rYC++Uk69vPcbuaJMkpSW5KcmWSryW5PEnauZuSLGiv35HkG+3YpUku7hvmpCRfTXJ33yrtj/Q1zLznt/vYmGRpO/abSda0Y1cl2XtA70uT3JVkU5IPj+ZDlSRJmkqmj3cDz4IlwOFVNR8gyZnAfOBIYH9gTZJVre68qjqj1e0NvKaqHksyD1gJLBgw1yuAw4BvAbcAxwNf2XkyyQHAB4BXAg8BXwI29l0/BzgBOAS4FrhyaF/9kvwC8CvAz1XVo0le2E59qqoubTV/CLwD+NhwDbdrXg8cUlWVZNYIdYuARQDT9ps94GOQJEmaXKbiSvBQJwArq2pHVd0H3AwcPUzdnsClSTYDVwC73NPbrK6qf6yqJ4EN9LYy9DsGuLmqHqiqH7Zx+11TVU+2rRMvHsV8pwF/UVWPAlTVA+344W0VezPwVnrBfCTfBx4DLkvy74FHhyuqquVVtaCqFkzbe+YoWpMkSZo8uhCCM8q6xcB99FaMFwA/NoprHu97vYOnrqwPmrv/+tH0GaCGOb4CeFdVHQH8HrDXSANU1RP0wvlV9FaVPzeKeSVJkqaUqRiCHwL27Xu/CliYZFqS2cBJwOph6mYC97ZV3bcB03ZDL6uBk5O8IMl04Myn0X+/G4C379zz27cdYl/g3iR70lsJHlGSfYCZVfU3wHvpbRWRJEnqlCm3J7iq7k9yS/tas88C5wPH0tuLW8D5VfXtJPcDTyTZSG8l9RLgqiRvAG4EHtkNvWxL8iHgdnr7hu8Ctg+4bFN/X1X1kb7xPpdkPrA2yT8DfwO8j96+49uBvwM2M3KIpp376yR70VtZfsrDd5IkSVNdqob77bp2lyT7VNXDbSX4auDjVXX1ePc1FjPmzKs5Z1/E1qWnj3crkiRJu5RkXVUN+nKDKbkdYqK5IMkGYAtwD3DNOPcjSZLUea4Ea6AFCxbU2rVrx7sNSZKkgVwJliRJkkZgCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnGIIlSZLUOYZgSZIkdY4hWJIkSZ1jCJYkSVLnTB/vBjTxbd62nblLrvuRY1uXnj5O3UiSJD1zrgRLkiSpcwzBkiRJ6pzOheAks5KcO4q6uUneMsq6Lbunu90rySlJPtNen5Pk4vHuSZIkaSLoXAgGZgEDQzAwFxgYgiVJkjT5dDEELwUOSrIhybL0LEuyJcnmJAv76k5sdYvbiu+Xk6xvP8cNmijJf0qyJsmmJL/Xjl3YvxKd5IIkvz1S/TBjvq7NvzHJF9uxY5J8Nckd7b8/O6CvN7T73Zhk1ag+NUmSpCmki98OsQQ4vKrmAyQ5E5gPHAnsD6xpwXAJcF5VndHq9gZeU1WPJZkHrAQWjDRJktcC84BjgADXJjkJ+ARwEXBJK30j8LqR6qtqVd+Ys4FLgZOq6p4kL2ynvtaOPZHkNOBDwJm7+Aw+CPx8VW1LMmsUn5kkSdKU0sUQPNQJwMqq2gHcl+Rm4Gjg+0Pq9gQuTjIf2AEcPGDc17afO9r7fYB5VfX/J3lRkgOA2cCDVfX3Sd4zXD3Qv1L7KmBVVd0DUFUPtOMzgf/Rwnm1XnflFmBFkk8CnxquIMkiYBHAtP1mDxhOkiRpcjEE91ZdR2MxcB+9FeM9gMdGMe5/rao/H+bclcBZwE/QWxkeVN8/Zg1z/A+AG6vq9UnmAjftqrGqemeSnwNOBzYkmV9V9w+pWQ4sB5gxZ95wc0qSJE1aXdwT/BCwb9/7VcDCJNPadoOTgNXD1M0E7q2qJ4G3AdMGzHM98PYk+wAkOTDJi9q5TwBvoheErxxF/U63AicneWmr2bkdYiawrb0+Z0BfJDmoqm6vqg8C3wNeMugaSZKkqaRzK8FVdX+SW9rXmn0WOB84FthIb5X1/Kr6dpL7gSeSbARW0NvDe1WSNwA3Ao8MmOeGJC8Dbk0C8DDwq8B3qurOJPsC26rq3kH1fWN+t21T+FSSPdq51wB/TG87xG8BXxrFx7CsbZ0I8MV275IkSZ2RKn/TrV2bMWdezTn7oh855j+bLEmSJqIk66pqxC8v2KmL2yEkSZLUcYZgSZIkdU7n9gRr7I44cCZr3f4gSZKmEFeCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DnTx7sBTXybt21n7pLrnnJ869LTx6EbSZKkZ86VYEmSJHWOIViSJEmdYwiWJElS5xiCJ6kk702y9+6qkyRJ6hJD8OT1XmA04Xa0dZIkSZ1hCJ4Ekjw/yXVJNibZkuR3gQOAG5Pc2Gr+NMnaJHcm+b127D3D1L02ya1J1ie5Isk+43VfkiRJ48UQPDm8DvhWVR1ZVYcDFwHfAk6tqlNbze9U1QLg5cDJSV5eVR/tr0uyP/B+4LSqeiWwFvit4SZMsqiF6rU7Ht3+LN+eJEnSc8sQPDlsBk5LcmGSE6tquFT6xiTrgTuAw4BDh6l5VTt+S5INwNnATw03YVUtr6oFVbVg2t4zd89dSJIkTRD+YxmTQFV9I8lRwC8C/zXJDf3nk7wUOA84uqoeTLIC2GuYoQJ8vqre/Gz3LEmSNJG5EjwJJDkAeLSq/jfwYeCVwEPAvq1kP+ARYHuSFwO/0Hd5f91twPFJfqaNu3eSg5+DW5AkSZpQXAmeHI4AliV5Evgh8B+AY4HPJrm37fe9A7gTuBu4pe/a5UPqzgFWJpnRzr8f+MZzdSOSJEkTQapqvHvQBDdjzryac/ZFTzm+denp49CNJEnSyJKsa18WsEtuh5AkSVLnuB1CAx1x4EzWuuorSZKmEFeCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHXO9PFuQBPf5m3bmbvkuoF1W5ee/hx0I0mS9My5EixJkqTOMQRLkiSpcwzBz6Ekc5O8ZRfntjwLc56S5Li+9yuSnLW755EkSZpMDMHPrbnAsCH4WXQKcNygIkmSpC6Z8iE4yTVJ1iW5M8mivuOvS7I+ycYkX2zH9knyF0k2J9mU5Mx2/M3t2JYkF/aN8XDf67OSrGivVyT5aJKvJrm7b+V1KXBikg1JFu+i52lJliVZ0/r4f9rxU5LclOTKJF9LcnmStHO/2I59pc39mSRzgXcCi9ucJ7YpThqmN0mSpM7owrdDvL2qHkjyPGBNkqvohf9LgZOq6p4kL2y1HwC2V9URAElekOQA4ELgKOBB4IYkv1JV1wyYdw5wAnAIcC1wJbAEOK+qzhhw7TtaH0cnmQHckuSGdu4VwGHAt4BbgOOTrAX+vO9+VgJU1dYkfwY8XFUfbvf0jhF6kyRJ6owpvxIMvCfJRuA24CXAPOBVwKqqugegqh5otacBf7Lzwqp6EDgauKmqvltVTwCXAyeNYt5rqurJqroLePEYe34t8GtJNgC3Az/e+gZYXVX/WFVPAhvobbE4BLh75/0AK59pb0kWJVmbZO2OR7ePsX1JkqSJbUqvBCc5hV6wPbaqHk1yE7AXEKCGu2SY49nFFP21ew059/goxxhOgHdX1fU/crB3P/3j7qD3ZzjW8Qf2VlXLgeUAM+bMG+6zkiRJmrSm+krwTODBFoAPobcCDHArcHKSlwL0bYe4AXjXzouTvIDeSuzJSfZPMg14M3BzK7kvycuS7AG8fhT9PATsO4q664H/kGTP1sfBSZ6/i/qvAT/d9gADLHwac0qSJHXGVA/BnwOmJ9kE/AG9LRFU1XeBRcCn2laJv2r1fwi8oD0AtxE4taruBf4LcCOwEVhfVX/d6pcAnwG+BNw7in42AU+0h/FGfDAOuAy4C1jfvjbtz9nFqn1V/QA4F/hckq8A9wE79zB8Gnj9kAfjJEmSOi1V/qZ7KkiyT1U93L4t4k+Ab1bVR3bH2DPmzKs5Z180sM5/NlmSJI23JOuqasGguqm+Etwlv9kepLuT3jaQPx/nfiRJkiasKf1gXJe0Vd/dsvIrSZI01RmCNdARB85krVsdJEnSFOJ2CEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHXO9PFuQBPf5m3bmbvkujFft3Xp6c9CN5IkSc+cK8GSJEnqHEOwJEmSOscQLEmSpM7pXAhOMivJuaOom5vkLaOs2zKKuhVJzhptn7tLkofbf0fVpyRJUhd0LgQDs4CBIRiYCwwMwZIkSZp8uhiClwIHJdmQZFl6liXZkmRzkoV9dSe2usVtJfXLSda3n+N2NUkb9+IkdyW5DnhR37kPJlnT5lzeag9Ksr6vZl6SdcOM+zNJvpBkY+vjoCT7JPlie785yS8P6O2wJKvbvW1KMm8sH6AkSdJk18WvSFsCHF5V8wGSnAnMB44E9gfWJFnV6s6rqjNa3d7Aa6rqsRYaVwILdjHP64GfBY4AXgzcBXy8nbu4qn6/jfu/gDOq6tNJtieZX1UbgF8HVgwz7uXA0qq6Osle9P4i88/A66vq+0n2B25Lcm1V1Qi9vRP471V1eZIfA6bt+iOTJEmaWrq4EjzUCcDKqtpRVfcBNwNHD1O3J3Bpks3AFcChA8Y9qW/cbwFf6jt3apLb21ivBg5rxy8Dfj3JNGAh8Jf9AybZFziwqq4GqKrHqupRIMCHkmwCvgAcSC94j+RW4H1J/jPwU1X1g6EFSRYlWZtk7Y5Htw+4VUmSpMnFENwLkKOxGLiP3orxAuDHRnHNU1Zi2+rtJcBZVXUEcCmwVzt9FfALwBnAuqq6f5S9vhWYDRzVVrjv6xvzqU1V/SXwS8APgOuTvHqYmuVVtaCqFkzbe+YublGSJGny6WIIfgjYt+/9KmBhkmlJZtNbwV09TN1M4N6qehJ4G4O3EKwC3tTGnQOc2o7vDKffS7IP8C/fGFFVjwHXA38K/MXQAavq+8A/JvkVgCQz2jaNmcB3quqHSU4FfmpXjSX5aeDuqvoocC3w8gH3IkmSNKV0LgS31dVb2kNpy4CrgU3ARnpbFs6vqm+3Y0+0B9AW01u9PTvJbcDBwCMDproa+CawmV6ovbnN/0/0Vn83A9cAa4Zcdzm9FeQbRhj3bcB72taHrwI/0a5ZkGQtvVXhrw3obSGwJckG4BDgfw6olyRJmlIy8rNTGg9JzgNmVtUHxruXnWbMmVdzzr5ozNdtXXr6s9CNJEnSyJKsq6pdfXkB0M1vh5iwklwNHETvYTlJkiQ9SwzBE0hVvX68e5AkSeoCQ7AGOuLAmax1a4MkSZpCOvdgnCRJkmQIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnTN9vBvQxLd523bmLrnuWZ1j69LTn9XxJUmS+rkSLEmSpM4xBEuSJKlzDMGSJEnqnAkfgpPMSnLuKOrmJnnLKOu2jLGHy5IcOqBmRZKznm5fQ665KcmCsVwjSZKk0ZvwIRiYBQwMwcBcYExhc7Sq6jeq6q6neflcnqW+hpNk2nM1lyRJ0mQ1GULwUuCgJBuSLEvPsiRbkmxOsrCv7sRWt7itwH45yfr2c9yuJklySluBvTLJ15JcniTt3L+szCZ5R5JvtGOXJrm4b5iTknw1yd19q8I/0tcw857f7mNjkqV9p96QZHWb68RWO+w9td5vTPKXwOZ27APtPj6fZGWS89rxg5J8Lsm6NtYhY/vjkCRJmvwmw1ekLQEOr6r5AEnOBOYDRwL7A2uSrGp151XVGa1ub+A1VfVYknnASmDQFoNXAIcB3wJuAY4HvrLzZJIDgA8ArwQeAr4EbOy7fg5wAnAIcC1w5dC++iX5BeBXgJ+rqkeTvLDv9PSqOibJLwK/C5wGfGcX93RM+5zuaYH9zHY/04H1wLpWtxx4Z1V9M8nPAZcArx6mt0XAIoBp+80e8LFJkiRNLpMhBA91ArCyqnYA9yW5GTga+P6Quj2Bi5PMB3YAB49i7NVV9Y8ASTbQ28rwlb7zxwA3V9UDreaKIeNeU1VPAnclefEo5jsN+IuqehRg57jNp9p/17U+Bt3T6qq6p70+AfjrqvpB6/PT7b/7AMcBV7RFboAZwzVWVcvpBWZmzJlXo7gXSZKkSWMyhuAMLgFgMXAfvRXjPYDHRnHN432vd/DUz2fQ3P3Xj6bPACMFzJ1j9fexq3t6ZBRz7wH8085VdUmSpK6aDHuCHwL27Xu/CliYZFqS2cBJwOph6mYC97aV2bcBu+OBsdXAyUlekGQ6vS0HY+2/3w3A29vWDYZshxjOaO/pK8C/S7JXW/09HaCqvg/ck+QNbb4kOXIU9yBJkjSlTPgQXFX3A7e0B+GWAVcDm+jtxf0ScH5Vfbsde6I9YLaY3l7Xs5PcRm/bwCPDzzCmXrYBHwJuB74A3AVsH3DZ0L76x/scvb3Da9v2i/MGjDWqe6qqNW3cjfS2Vazt6/OtwDuSbATuBH55wJySJElTTqrc7jkWSfapqofbSvDVwMer6urx7muovj73prd6vqiq1j+dsWbMmVdzzr5o9zY4xNalpz+r40uSpG5Isq6qBv57C5NxT/B4uyDJacBe9LYzXDPO/YxkefsHPvYC/sfTDcCSJElTkSvBGmjBggW1du3a8W5DkiRpoNGuBE/4PcGSJEnS7mYIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUudMH+8GNPFt3raduUuuG+82/sXWpaePdwuSJGmScyVYkiRJnWMIliRJUudMmBCcZFaSc0dRNzfJW0ZZt2WMPVyW5NABNSuSnPV0+xow9juT/NozuP59z2R+SZKkrpgwIRiYBQwMwcBc4BmFzZFU1W9U1V1P8/K5PMO+qurPqup/PoMhDMGSJEmjMJFC8FLgoCQbkixLz7IkW5JsTrKwr+7EVre4rcB+Ocn69nPcriZJckqSm5JcmeRrSS5PknbupiQL2ut3JPlGO3Zpkov7hjkpyVeT3N23KvwjfQ0z581JPtnGXJrkrUlWt3s7qNVdkOS8vl4ubDXfSHJiO35Ofy9JPtPGXwo8r81/eTv3q+36DUn+PMm09rOi73P9kV4lSZK6YCJ9O8QS4PCqmg+Q5ExgPnAksD+wJsmqVndeVZ3R6vYGXlNVjyWZB6wEFgyY6xXAYcC3gFuA44Gv7DyZ5ADgA8ArgYeALwEb+66fA5wAHAJcC1w5tK9hHAm8DHgAuBu4rKqOSfIfgXcD7x3mmumt5heB3wVOG+mGqmpJknf1fX4vAxYCx1fVD5NcArwVuBM4sKoOb3WzRhpTkiRpqppIK8FDnQCsrKodVXUfcDNw9DB1ewKXJtkMXAHsck9vs7qq/rGqngQ20NvK0O8Y4OaqeqCqftjG7XdNVT3Ztk68eJT3s6aq7q2qx4H/A9zQjm8eZv6dPtX+u24XNSP5t8BR9P7ysKG9/2l6Afynk3wsyeuA7w93cZJFSdYmWbvj0e1jnFqSJGlim0grwUNllHWLgfvorbTuATw2imse73u9g6d+DoPm7r9+tH32X/Nk3/snh5l/6DX9PT7Bj/7lZa8Rrg3wP6rqvzzlRHIk8PPA/wu8EXj70JqqWg4sB5gxZ16NMIckSdKkNJFWgh8C9u17vwpY2PawzgZOAlYPUzcTuLet6r4NmLYbelkNnJzkBUmmA2c+jf6fLVuB+Un2SPISeqvWO/0wyZ7t9ReBs5K8CCDJC5P8VJL9gT2q6ir+dcuHJElSp0yYleCquj/JLe1rzT4LnA8cS28vbgHnV9W3k9wPPJFkI7ACuAS4KskbgBuBR3ZDL9uSfAi4nd6+4buAQXsCNvX3VVUfeaZ9jOAW4B562yi2AOv7zi0HNiVZX1VvTfJ+4IYkewA/pLfy+wPgL9oxgKesFEuSJE11qfI33cNJsk9VPdxWgq8GPl5VV493X+Nhxpx5Nefsi8a7jX/hP5ssSZJGkmRdVQ36koQJtR1iormgPVC2hd7K6zXj3I8kSZJ2kwmzHWKiqarzxrsHSZIkPTsMwRroiANnstYtCJIkaQpxO4QkSZI6xxAsSZKkzjEES5IkqXMMwZIkSeocQ7AkSZI6xxAsSZKkzjEES5IkqXMMwZIkSeocQ7AkSZI6xxAsSZKkzjEES5IkqXMMwZIkSeocQ7AkSZI6Z/p4N6CJb/O27cxdct14tzHpbF16+ni3IEmSRuBKsCRJkjrHECxJkqTOMQRLkiSpc6ZMCE4yK8m5o6ibm+Qto6zbMszxA5JcOYrr3zfk/cODrumrXZHkrNHWS5IkaWymTAgGZgEDQzAwFxgYgkdSVd+qqtEE1PcNLtn90jOV/lwlSZJ2u6kUlpYCByXZkGRZC4PLkmxJsjnJwr66E1vd4rbi++Uk69vPcbuapH+FOMk5ST6V5HNJvpnkj9vxpcDz2hyXDxjv15JsSrIxyf/qO3VSkq8muXvnqnCSfZJ8sfW5Ockv9/X0t0kuAdYDL0nyjiTfSHJTkkuTXNxqZye5Ksma9nP8mD9pSZKkSW4qfUXaEuDwqpoPkORMYD5wJLA/sCbJqlZ3XlWd0er2Bl5TVY8lmQesBBaMYd75wCuAx4GvJ/lYVS1J8q6dvYwkyWHA7wDHV9X3kryw7/Qc4ATgEOBa4ErgMeD1VfX9JPsDtyW5ttX/LPDrVXVukgOADwCvBB4CvgRsbHX/HfhIVX0lyU8C1wMvG6a3RcAigGn7zR7DxyFJkjTxTaUQPNQJwMqq2gHcl+Rm4Gjg+0Pq9gQuTjIf2AEcPMZ5vlhV2wGS3AX8FPAPo7z21cCVVfU9gKp6oO/cNVX1JHBXkhe3YwE+lOQk4EngQGDnub+rqtva62OAm3eOl+SKvvs6DTg0yc559kuyb1U91N9YVS0HlgPMmDOvRnk/kiRJk8JUDsEZXALAYuA+eivGe9BbbR2Lx/te72Bsn2mAkQLm40PqAN4KzAaOqqofJtkK7NXOPTJM/XD2AI6tqh+MoU9JkqQpZSrtCX4I2Lfv/SpgYZJpSWYDJwGrh6mbCdzbVl3fBkzbTf38MMmeA2q+CLwxyY8DDNlyB76WAAAgAElEQVQOMZyZwHdaAD6V3qrzcFYDJyd5QZLpwJl9524A3rXzTVsBlyRJ6pQpE4Kr6n7glvYg3DLgamATvb2wXwLOr6pvt2NPtAfRFgOXAGcnuY3eloFHhp9hzJYDm3b1YFxV3Qn8EXBzko3Afxsw5uXAgiRr6a0Kf22EcbcBHwJuB74A3AVsb6ff08bY1LZvvHP0tyRJkjQ1pMrtnlNRkn2q6uG2Enw18PGquvrpjDVjzryac/ZFu7fBDti69PTxbkGSpM5Jsq6qBn7JwZRZCdZTXJBkA7AFuAe4Zpz7kSRJmjCm8oNxnVZV5413D5IkSROVIVgDHXHgTNb6q31JkjSFuB1CkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnWMIliRJUucYgiVJktQ5hmBJkiR1jiFYkiRJnTN9vBvQxLd523bmLrluvNvQBLN16enj3YIkSU+bK8GSJEnqHEOwJEmSOmfcQnCSm5IsGK/5RyPJLyVZ0l5fkOS88e5JkiRJz9yk3BOcZHpVPfFsz1NV1wLXPtvzSJIk6bm1y5XgJHOT/G2SS5PcmeSGJM9r5/5lJTfJ/km2ttfnJLkmyaeT3JPkXUl+K8kdSW5L8sK+KX41yVeTbElyTLv++Uk+nmRNu+aX+8a9IsmngRuG9HlhknP73l+Q5LeTnJLk5iSfTPKNJEuTvDXJ6iSbkxzU6v9dktvbfF9I8uK+OS8e8BmtSPKnSW5McneSk1v/f5tkRV/da5PcmmR9u4992vGlSe5KsinJh9uxN7TPZGOSVX1/Fl9u169Pclw7vkeSS9qfz2eS/E2Ss9q5o9r9r0tyfZI57fh7+ub8xK7uT5IkaSoazXaIecCfVNVhwD8BZ47imsOBtwDHAH8EPFpVrwBuBX6tr+75VXUccC7w8Xbsd4AvVdXRwKnAsiTPb+eOBc6uqlcPme8TwMK+928ErmivjwT+I3AE8Dbg4Ko6BrgMeHer+QrwqtbjJ4DzR3GP/V4AvBpYDHwa+AhwGHBEkvlJ9gfeD5xWVa8E1gK/1f5C8HrgsKp6OfCHbbwPAj9fVUcCv9SOfQd4Tbt+IfDRdvzfA3Pb/f1G+4xIsifwMeCsqjqK3uf7R+2aJcAr2pzvHOO9SpIkTXqj2Q5xT1VtaK/X0Qtcg9xYVQ8BDyXZTi8YAmwGXt5XtxKgqlYl2S/JLOC1wC/17b/dC/jJ9vrzVfXA0Mmq6o4kL0pyADAbeLCq/j7JTwNrqupegCT/h39dRd5ML2QD/Bvgr9pK6Y8B94ziHvt9uqoqyWbgvqra3Oa7k97n9W+AQ4FbktDmuBX4PvAYcFmS64DPtPFuAVYk+STwqXZsT+DiJPOBHcDB7fgJwBVV9STw7SQ3tuM/S+8vI59vc04D7m3nNgGXJ7kGuGa4G0qyCFgEMG2/2WP8OCRJkia20YTgx/te7wCe114/wb+uJO+1i2ue7Hv/5JA5a8h1BQQ4s6q+3n8iyc8Bj+yizyuBs4CfoLeaO5ZePgb8t6q6NskpwAW7mGc4/WMOnW86vc/t81X15qEXtm0g/xZ4E/Au4NVV9c52v6cDG1rwfTdwH72V7T3ohWfofV7DCXBnVR07zLnTgZPorTJ/IMlhQ/dYV9VyYDnAjDnzhv45SZIkTWrP5NshtgJHtddnPc0xFgIkOQHYXlXbgeuBd6ctXyZ5xSjH+gS9IHkWvUA8FjOBbe312WO8djRuA45P8jMASfZOcnDbFzyzqv4GeC8wv50/qKpur6oPAt8DXtJ6vLet+L6N3sou9LZynNn2Br8YOKUd/zowO8m/bI9IcliSPYCXVNWN9LZ9zAL2eRbuWZIkacJ6Jt8O8WHgk0neBnzpaY7xYJKvAvsBb2/H/gC4CNjUgvBW4IxBA1XVnUn2Bbbt3P4wBhcAVyTZRi+wvnSM1w/q7btJzgFWJpnRDr8feAj46yR70Vu5XdzOLUsyrx37IrARuAS4KskbgBv511Xxq+itJG8BvgHcTu8vFP/cHpD7aJKZ9P6sL2o1/7sdC/CRqvqn3Xm/kiRJE12q/E33ZJdkn6p6OMmPA6uB46vq27tr/Blz5tWcsy/aXcNpivCfTZYkTURJ1lXVwH+LYlJ+T7Ce4jPtocIfA/5gdwZgSZKkqcgQPAVU1Snj3YMkSdJkYgjWQEccOJO1/upbkiRNIc/k2yEkSZKkSckQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOscQLEmSpM4xBEuSJKlzDMGSJEnqHEOwJEmSOmf6eDegiW/ztu3MXXLdeLehCWzr0tPHuwVJksbElWBJkiR1jiFYkiRJnWMIliRJUucYgpskByS5cgL0cVmSQ9vrrUn2H8O1K5Kc9ex1J0mSNDX4YFxTVd8Cxj1AVtVvjHcPkiRJU92UXQlOcmGSc/veX5Dkt9OzLMmWJJuTLGzn5ybZ0l5PS/Lhdn5Tkne340cluTnJuiTXJ5kzzLwrkvxpkhuT3J3k5CQfT/K3SVb01f1pkrVJ7kzye33Hb0qyYMC9PZzk/0uyPskXk8wepuaDSda0+1yeJH3jX5hkdZJvJDlxzB+uJEnSJDdlQzDwCWBh3/s3AlcA/x6YDxwJnAYsGybMLgJeCryiql4OXJ5kT+BjwFlVdRTwceCPRpj7BcCrgcXAp4GPAIcBRySZ32p+p6oWAC8HTk7y8jHc2/OB9VX1SuBm4HeHqbm4qo6uqsOB5wFn9J2bXlXHAO8d4VpJkqQpbcqG4Kq6A3hR2+t7JPBgVf09cAKwsqp2VNV99ELk0UMuPw34s6p6oo31APCzwOHA55NsAN4P/JsRpv90VRWwGbivqjZX1ZPAncDcVvPGJOuBO+gF5EPHcHtPAn/VXv/vdk9DnZrk9iSb6QXyw/rOfar9d11fPz8iyaK2Ur12x6Pbx9CaJEnSxDfV9wRfSW+f70/QWxkGyCiuC1DDHLuzqo4dxfWPt/8+2fd65/vpSV4KnAccXVUPtm0Se41i3JH8SK9J9gIuARZU1T8kuWDI+Dt72sEI/w9U1XJgOcCMOfOGfhaSJEmT2pRdCW4+AbyJXhDe+c0Pq4CFbd/vbOAkYPWQ624A3plkOkCSFwJfB2YnObYd2zPJYTw9+wGPANuTvBj4hTFevwf/+hDfW4CvDDm/M/B+L8k+TIAH/iRJkiaSKb0SXFV3JtkX2FZV97bDVwPHAhvpraCeX1XfTjK379LLgIOBTUl+CFxaVRe3rx/7aJKZ9D67i+htcRhrXxuT3NGuvRu4ZYxDPAIclmQdsJ0f3ftMVf1TkkvpbcfYCqwZa4+SJElTWXpbVzWZJHm4qvZ5ruabMWdezTn7oudqOk1CW5eePt4tSJIEQJJ17csHdmmqb4eQJEmSnsIQPAk9l6vAkiRJU9GU3hOs3eOIA2ey1l93S5KkKcSVYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHWOIViSJEmdYwiWJElS5xiCJUmS1DmGYEmSJHXO9PFuQBPf5m3bmbvkuvFuQxpXW5eePt4tSJJ2I1eCJUmS1DmGYEmSJHWOIViSJEmdM+lCcJJZSc4dRd3cJG8ZZd2WYY4fkOTKUVz/viHvHx50zS7G+qUkS57B9e9NsvfTvV6SJKkrJl0IBmYBA0MwMBcYGIJHUlXfqqqzRlH6vsElo57z2qpa+gyGeC9gCJYkSRpgMobgpcBBSTYkWZaeZUm2JNmcZGFf3YmtbnFb8f1ykvXt57hdTdK/QpzknCSfSvK5JN9M8sft+FLgeW2OyweM9bUkl7U+L09yWpJb2njH9M1zcXu9IslHk3w1yd1JzmrHT0nymb6xL27XvQc4ALgxyY3t3GuT3Nru94ok++zsO8ldSTYl+fDT+UOQJEmazCbjV6QtAQ6vqvkASc4E5gNHAvsDa5KsanXnVdUZrW5v4DVV9ViSecBKYMEY5p0PvAJ4HPh6ko9V1ZIk79rZywA/A7wBWASsobdKfQLwS/RWk39lmGvmtJpDgGuBEbdnVNVHk/wWcGpVfS/J/sD7gdOq6pEk/xn4rRayXw8cUlWVZNZw4yVZ1Hpl2n6zR3F7kiRJk8dkDMFDnQCsrKodwH1JbgaOBr4/pG5P4OIk84EdwMFjnOeLVbUdIMldwE8B/zCG6++pqs3t+jvbeJVkM72tG8O5pqqeBO5K8uIx9vsq4FDgliQAPwbcSu9zeQy4LMl1wGeGu7iqlgPLAWbMmVdjnFuSJGlCmwohOKOsWwzcR2/FeA96QXAsHu97vYOxf3b91z/Z9/7JXYzVf83O+3yCH93GstcI1wb4fFW9+Sknetsv/i3wJuBdwKt32bkkSdIUMxn3BD8E7Nv3fhWwMMm0JLOBk4DVw9TNBO5tK6tvA6btpn5+mGTP3TTWaPwdcGiSGUlm0guzO/Xf823A8Ul+BnrbQZIc3PYFz6yqv6H3IN1otnJIkiRNKZNuJbiq7m8PlG0BPgucDxwLbAQKOL+qvp3kfuCJJBuBFcAlwFVJ3gDcCDyym1paDmxKsr6q3rqbxhxRVf1Dkk8Cm4BvAncM6eWzSe6tqlOTnAOsTDKjnX8/vaD810n2ordavPjZ7lmSJGmiSZXbPbVrM+bMqzlnXzTebUjjauvS08e7BUnSKCRZV1UDv/xgMm6HkCRJkp6RSbcdQs+9Iw6cyVpXwSRJ0hTiSrAkSZI6xxAsSZKkzjEES5IkqXMMwZIkSeocQ7AkSZI6xxAsSZKkzjEES5IkqXMMwZIkSeocQ7AkSZI6xxAsSZKkzjEES5IkqXMMwZIkSeocQ7AkSZI6xxAsSZKkzpk+3g1o4tu8bTtzl1w33m1IE8rWpaePdwuSpGfAlWBJkiR1jiFYkiRJnTPpQ3CSWUnOHUXd3CRvGWXdlt3T3dOT5IIk541nD5IkSVPZpA/BwCxgYAgG5gIDQ/BUkGTaePcgSZI0kU2FELwUOCjJhiTL0rMsyZYkm5Ms7Ks7sdUtbiu+X06yvv0cN2iiJP8pyZokm5L8Xjt2Yf9KdFvF/e2R6ocZ83Vt/o1Jvth36tAkNyW5O8l7+uqvSbIuyZ1JFvUdfzjJ7ye5HTg2yS8m+VqSryT5aJLPtLrnJ/l46+uOJL886k9akiRpipgK3w6xBDi8quYDJDkTmA8cCewPrEmyqtWdV1VntLq9gddU1WNJ5gErgQUjTZLktcA84BggwLVJTgI+AVwEXNJK3wi8bqT6qlrVN+Zs4FLgpKq6J8kL+6Y8BDgV2Bf4epI/raofAm+vqgeSPK/d21VVdT/wfGBLVX0wyV7AN/vGXdk37u8AX6qqtyeZBaxO8oWqemS0H7gkSdJkNxVWgoc6AVhZVTuq6j7gZuDoYer2BC5Nshm4Ajh0wLivbT93AOvphdR5VXUH8KIkByQ5Eniwqv5+pPohY74KWFVV9wBU1QN9566rqser6nvAd4AXt+PvSbIRuA14Sd+YO4Cr2utDgLt3jksv4Pffx5IkG4CbgL2Anxx6s0kWJVmbZO2OR7cP+GgkSZIml6mwEjxURlm3GLiP3orxHsBjoxj3v1bVnw9z7krgLOAn6K0MD6rvH7NGOPd43+sdwPQkpwCnAcdW1aNJbqIXYgEeq6odfePuas4zq+rru6ihqpYDywFmzJk3Uo+SJEmT0lRYCX6I3paBnVYBC5NMa9sNTgJWD1M3E7i3qp4E3gYMepjseuDtSfYBSHJgkhe1c58A3kQvCF85ivqdbgVOTvLSVvNCdm0mvZXmR5McQm8leThfA346ydz2fmHfueuBdydJm/MVA+aUJEmacib9SnBV3Z/klva1Zp8FzgeOBTbSW2U9v6q+neR+4Im2lWAFvT28VyV5A3AjsMs9sVV1Q5KXAbe2/Pgw8KvAd6rqziT7Atuq6t5B9X1jfrc93PapJHu0c6/ZRRufA96ZZBPwdXpbIobr9QftYb3PJfkevb8E7PQH9PYwb2pBeCtwxq7uXZIkaapJlb/pnoqS7FNVD7eg+yfAN6vqI09nrBlz5tWcsy/avQ1Kk5z/bLIkTUxJ1lXViF92sNNU2A6h4f1me/jtTnrbKHa1N1mSJKlTJv12CA2vrfo+rZVfSZKkqc4QrIGOOHAma/3VryRJmkLcDiFJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOMQRLkiSpcwzBkiRJ6hxDsCRJkjrHECxJkqTOmT7eDWji27xtO3OXXDfebUiagLYuPX28W5Ckp8WVYEmSJHWOIViSJEmdYwiWJElS50yaEJxkVpJzR1E3N8lbRlm3Zfd0t3skWZDko8/g+nOSHLA7e5IkSZqKJk0IBmYBA0MwMBcYGIInoqpaW1XveQZDnAMYgiVJkgaYTCF4KXBQkg1JlqVnWZItSTYnWdhXd2KrW9xWfL+cZH37OW7QREn+U5I1STYl+b127ML+legkFyT57ZHqhxnz4TbGuiRfSHJMkpv+b3v3HmZ3Vd97/P0hQJCLiRe0EbVBGrQCGiVQUUDwALWFejlgoVgFOT209VgqLVKqraKntrHYA2qqbbSWVhF4QKEoVfCCgCgSwiUBCl7zqIBQUFBAIoTv+WOv0c0wk5lkbtnze7+eZz+z9+/3/a31XWtmdr5Ze+09Sb6T5BUtZr8kn+lr/6N9Mce1449awU5yQos9DFgCnNHG/rgkuye5tPV5UZIF7ZrjktzU8j1rg78TkiRJA26QPiLtJGDXqloMkORQYDHwfODJwIokl7W4E6rqkBa3NXBgVT2YZBFwJr1icURJDgIWAXsCAS5Isi9wFnAa8MEW+rvAy0eLr6rLhjW9DfDlqvqLJOcBfwMcCDwX+DfgghHSeQ6wP7AdcEuSD42Wd1Wdm+RNbexXJ9kC+ADwyqr67/afhHcDx7Q52rGq1iaZP8o8HAscCzDn8duP1q0kSdJAGqQieLi9gTOrah1wR5JLgT2AnwyL2wJYlmQxsA7YeYx2D2q3a9vjbYFFVfUvSZ7S9txuD/y4qr7XVmgfEw8ML4J/Dnyu3V8NrK2qh5KspreFYyQXVtVaYG2SO4GnjpF7v2cDuwKfTwIwB7i9nVtFb8X4fOD8kS6uquXAcoC5CxbVBvQrSZK0yRvkIjjjjDseuIPeivFmwIPjaPfvquqfRzh3LnAY8Cv0VobHiu/3UFUNFZOPAGsBquqRJKN9H9b23V9H7/v1MI/exrLVesZxY1XtNcK5g4F9gVcAf51kl6p6eIz8JUmSZo1B2hP8U3rbAoZcBhyeZE6S7ekVdVeNEDcPuL2qHgFeR29FdH0uAo5Jsi1Akh2SPKWdOws4gl4hfO444qfCHcBTkjwpyVzgkL5z/WO/Bdg+yV4try2S7JJkM+AZVXUJcCK9NxxuO4X5SpIkbXIGZiW4qu5OckV7U9hn6RVwewHXAwWcWFU/THI38HCS64HT6e3h/WSS1wCXAPeP0c/FSX4d+FrbRnAf8PvAnVV1Y5LtgFur6vax4id3Bn6R30NJ3gV8HfgucHPf6dOBf0ryM3pzcxjw/iTz6H2vTwO+AXy8HQtwalXdMxW5SpIkbaryy1fopZHNXbCoFhx12kynIWkTtGbpwTOdgiQ9SpKVVTXqhyAMGaTtEJIkSdKksAiWJElS5wzMnmDNnN12mMfVvuQpSZJmEVeCJUmS1DkWwZIkSeoci2BJkiR1jkWwJEmSOsciWJIkSZ1jESxJkqTOsQiWJElS51gES5IkqXMsgiVJktQ5FsGSJEnqHItgSZIkdY5FsCRJkjrHIliSJEmds/lMJ6BN3+pb72XhSRfOdBqSNCnWLD14plOQtAlwJViSJEmdYxEsSZKkzrEIliRJUucMTBGc5KvjiHlzkq2nIZeFSY7se7wkyfunoJ81SZ68AfGnJzlssvOQJEmabQamCK6qF48j7M3ABhXBSeZsRDoLgV8UwVV1dVUdtxHtSJIkaQYMTBGc5L72db8kX05ybpKbk5yRnuOApwGXJLmkxR6U5GtJrklyTpJt2/E1Sd6e5CvAa1p770lyVZJvJNmnxS1Mcnm7/pokQ4X4UmCfJNclOb7l9Jl2zROTnJ9kVZIrkzyvHT85yUdbX99p+Q6N7fwkK5PcmOTY8cxFkn9oOX0xyfYjxLw9yYokNyRZniTt+IhjlSRJ6pKBKYKHeQG9Vd/nAs8CXlJV7wduA/avqv3bNoK/Ag6oqhcCVwN/1tfGg1W1d1Wd1R5vXlV7tnbf0Y7dCRzYrj8cGNrycBJweVUtrqpTh+X2TuDaqnoe8Fbg3/vOPQf4TWBP4B1JtmjHj6mq3YElwHFJnjTG+LcBrml5XdqXb79lVbVHVe0KPA44pO/cSGN9lCTHJrk6ydXrHrh3jHQkSZIGy6B+TvBVVfUDgCTX0due8JVhMS+iVyRf0RZBtwS+1nf+7GHxn2pfV7b2ALYAliVZDKwDdh5HbnsDhwJU1ZeSPCnJvHbuwqpaC6xNcifwVOAH9ArfV7eYZwCLgLvX08cjffl/vC/3fvsnOZHe9pAnAjcCn17PWB+lqpYDywHmLlhU68lFkiRp4AxqEby27/46Rh5HgM9X1e+N0sb9o7TZ397xwB3A8+mtmj84jtwywrGhIvIxeSfZDzgA2KuqHkjyZWCrcfQzUvu9BJKtgA8CS6rq+0lOHtbmSGOVJEnqjEHdDjGanwLbtftXAi9J8msASbZOMp6V3H7zgNur6hHgdcDQm+j6+xnuMuC1rc/9gLuq6idj9PHjVgA/h94K9lg2A4Y+BeJIHrsKPlTw3tX2QfuJEZIkSX1m2yrgcuCzSW5v+4KPBs5MMred/yvgGxvQ3geBTyZ5DXAJv1w9XgU8nOR64HTg2r5rTgb+Nckq4AHgqDH6+BzwRy3+FnrF+1juB3ZJshK4l95+5V+oqnuSfBhYDawBVoyjTUmSpM5Ilds9B02S+6pq2+nqb+6CRbXgqNOmqztJmlJrlh480ylImkJJVlbVkrHiZtt2CEmSJGlMs207RCdM5yowwG47zONqV04kSdIs4kqwJEmSOsciWJIkSZ1jESxJkqTOsQiWJElS51gES5IkqXMsgiVJktQ5FsGSJEnqHItgSZIkdY5FsCRJkjrHIliSJEmdYxEsSZKkzrEIliRJUudYBEuSJKlzLIIlSZLUOZvPdALa9K2+9V4WnnThTKchSRrFmqUHz3QK0sBxJViSJEmdYxEsSZKkzulsEZxkfpI3jiNuYZIjxxl3wwjHn5bk3HFc/9Zhj+8b65pxtHl0kmXt/slJTphom5IkSbNBZ4tgYD4wZhEMLATGLIJHU1W3VdVh4wh969ghkiRJmgxdLoKXAjsluS7JKek5JckNSVYnObwvbp8Wd3xb8b08yTXt9uL1ddK/QtxWZj+V5HNJvpnk79vxpcDjWh9njNHe65OsSnJ9ko+1Y7+T5OtJrk3yhSRPHaON45Lc1No5a3zTJUmSNHt0+dMhTgJ2rarFAEkOBRYDzweeDKxIclmLO6GqDmlxWwMHVtWDSRYBZwJLNqDfxcALgLXALUk+UFUnJXnTUC6jSbIL8DbgJVV1V5IntlNfAV5UVZXkD4ATgT8fY+w7VtXaJPM3IHdJkqRZoctF8HB7A2dW1TrgjiSXAnsAPxkWtwWwLMliYB2w8wb288WquhcgyU3ArwLfH+e1LwPOraq7AKrqR+3404GzkywAtgS+O0Y7q4AzkpwPnD9SQJJjgWMB5jx++3GmJ0mSNBi6vB1iuIwz7njgDnorxkvoFZ0bYm3f/XVs2H9EAtQIxz8ALKuq3YA/BLYao52DgX8EdgdWJnlMDlW1vKqWVNWSOVvP24AUJUmSNn1dLoJ/CmzX9/gy4PAkc5JsD+wLXDVC3Dzg9qp6BHgdMGeS8nkoyRZjxHwR+N0kTwLo2w4xD7i13T9qfQ0k2Qx4RlVdQm/bxHxg243OWpIkaQB1djtEVd2d5Ir2prXP0isI9wKup7faemJV/TDJ3cDDSa4HTgc+CHwyyWuAS4D7Jyml5cCqJNdU1WtHyfnGJO8GLk2yDrgWOBo4GTgnya3AlcCO6+lnDvDxJPPorSyfWlX3TNIYJEmSBkKqRnp1XfqluQsW1YKjTpvpNCRJo/DPJku/lGRlVY35oQVd3g4hSZKkjrIIliRJUud0dk+wxm+3HeZxtS+1SZKkWcSVYEmSJHWORbAkSZI6xyJYkiRJnWMRLEmSpM6xCJYkSVLnWARLkiSpcyyCJUmS1DkWwZIkSeoci2BJkiR1jkWwJEmSOsciWJIkSZ1jESxJkqTOsQiWJElS52w+0wlo07f61ntZeNKFM52GJElTbs3Sg2c6BU0TV4IlSZLUORbBkiRJ6hyLYEmSJHXOwBTBSeYneeM44hYmOXKccTeMI+70JIeNN8+JSvLVCVy7X5IXT2Y+kiRJs9HAFMHAfGDMIhhYCIxZBG+qqmoiRex+gEWwJEnSGAapCF4K7JTkuiSnpOeUJDckWZ3k8L64fVrc8W3F9/Ik17TbeovE1u6yJDcluRB4St+5tydZ0fpc3mJ3SnJNX8yiJCtHaPfLSU5NclmS/0qyR5JPJflmkr/pi7uvfd2vXXNukpuTnJEk7dyaJE9u95e0uIXAHwHHt7Hvk2T7JJ9sOa9I8pJ2zUtbzHVJrk2y3cZ8QyRJkgbVIH1E2knArlW1GCDJocBi4PnAk4EVSS5rcSdU1SEtbmvgwKp6MMki4ExgyXr6eTXwbGA34KnATcBH27llVfWu1u7HgEOq6tNJ7k2yuKquA94AnD5K2z+vqn2T/CnwH8DuwI+Abyc5taruHhb/AmAX4DbgCuAlwFdGariq1iT5J+C+qnpvy/lSG9oAABH5SURBVPETwKlV9ZUkzwQuAn4dOAH4P1V1RZJtgQeHt5fkWOBYgDmP33490yVJkjR4BmkleLi9gTOral1V3QFcCuwxQtwWwIeTrAbOAZ47Rrv79rV7G/ClvnP7J/l6a+tl9ApUgI8Ab0gyBzgc+MQobV/Qvq4Gbqyq26tqLfAd4BkjxF9VVT+oqkeA6+ht9dgQBwDLklzX+n58W/W9Avh/SY4D5lfVw8MvrKrlVbWkqpbM2XreBnYrSZK0aRukleDhMs6444E76K0Yb8YIq54jqMd0lmwFfBBYUlXfT3IysFU7/UngHfQK5pUjrOgOWdu+PtJ3f+jxSN+L/ph1fTEP88v/wGzF6DYD9qqqnw07vrRt9fht4MokB1TVzetpR5IkaVYZpJXgnwL9e1cvAw5PMifJ9vRWcK8aIW4ecHtbTX0dMGeMfi4DjmjtLgD2b8eHis272haCX3xiRFU9SG+rwYeAf92YwW2gNfS2UgAc2nd8+NgvBt409CDJ0FaSnapqdVW9B7gaeM6UZitJkrSJGZgiuK2uXtHelHYKcB6wCrie3grsiVX1w3bs4STXJzme3urtUUmuBHYG7h+jq/OAb9LbsvAhetssqKp7gA+34+cDK4Zddwa9FeSLJzrWcXgn8L4kl9NbIR7yaeDVQ2+MA44DliRZleQmem+cA3hzm8frgZ8Bn52GnCVJkjYZqXrMK//aCElOAOZV1V/PdC6Tbe6CRbXgqNNmOg1JkqbcmqUHz3QKmqAkK6tqfR+CAAz2nuBNRpLzgJ3ovVlOkiRJmziL4ElQVa+e6Rym0m47zONq/2csSZJmkYHZEyxJkiRNFotgSZIkdY5FsCRJkjrHIliSJEmdYxEsSZKkzrEIliRJUudYBEuSJKlzLIIlSZLUORbBkiRJ6hyLYEmSJHWORbAkSZI6xyJYkiRJnWMRLEmSpM6xCJYkSVLnbD7TCWjTt/rWe1l40oUznYYkSZoEa5YePNMpbBJcCZYkSVLnWARLkiSpcwa+CE4yP8kbxxG3MMmR44y7YRxxpyc5bLx5bogk+yX5zFS0LUmSpFlQBAPzgTGLYGAhMGYRPBskca+3JEnSesyGIngpsFOS65Kckp5TktyQZHWSw/vi9mlxx7cV38uTXNNuL15fJ63dZUluSnIh8JS+c29PsqL1ubzF7pTkmr6YRUlWjtDuryX5QpLrWx47tVPbJjk3yc1JzkiS0fpqx7+c5G+TXAr8aev/yhb7riT39fX5lnZ8VZJ3bty0S5IkDa7ZUASfBHy7qhZX1VuA/wksBp4PHACckmRBi7u8xZ0K3AkcWFUvBA4H3j9GP68Gng3sBvxvoL9oXlZVe1TVrsDjgEOq6tvAvUkWt5g3AKeP0O4ZwD9W1fNbm7e34y8A3gw8F3gW8JLR+upra35VvbSq/gF4H/C+qtoDuG0oIMlBwCJgzzZPuyfZd4yxS5IkzSqzoQgebm/gzKpaV1V3AJcCe4wQtwXw4SSrgXPoFZvrs29fu7cBX+o7t3+Sr7e2Xgbs0o5/BHhDkjn0Cu1P9DeYZDtgh6o6D6CqHqyqB9rpq6rqB1X1CHAdve0c6+sL4Oy++3u1cTGs34Pa7VrgGuA59IriR0lybJKrk1y97oF71zsxkiRJg2Y27h3NOOOOB+6gt2K8GfDgOK6px3SWbAV8EFhSVd9PcjKwVTv9SeAd9ArmlVV19wbkurbv/jpg8zH6Arh/HGMI8HdV9c/rC6qq5cBygLkLFj1m3JIkSYNsNqwE/xTYru/xZcDhSeYk2Z7eCu5VI8TNA25vK62vA+aM0c9lwBGt3QXA/u34UBF6V5JtgV98YkRVPQhcBHwI+NfhDVbVT4AfJHkVQJK5SbZeTw6j9jWCK4FD2/0j+o5fBBzTrifJDkmeMvxiSZKk2Wzgi+C2unpFe6PYKcB5wCrgenorsCdW1Q/bsYfbG9COp7eielSSK4GdGXsV9Tzgm8BqekXtpa3/e4APt+PnAyuGXXcGvRXki0dp93XAcUlWAV8FfmU9Yx2rr35vBv4syVXAAuDe1sbF9LZHfK1tqTiXR//nQJIkadZLla90T6UkJwDzquqvp7nfrYGfVVUlOQL4vap65ca0NXfBolpw1GmTm6AkSZoRs/3PJidZWVVLxoqbjXuCNxlJzgN2ovcGtum2O7CsfYTaPcAxM5CDJEnSJskieApV1atnsO/L6b3pT5IkScNYBGtMu+0wj6tn+UsnkiSpWwb+jXGSJEnShrIIliRJUudYBEuSJKlzLIIlSZLUORbBkiRJ6hyLYEmSJHWORbAkSZI6xyJYkiRJnWMRLEmSpM6xCJYkSVLnWARLkiSpcyyCJUmS1DkWwZIkSeqczWc6AW36Vt96LwtPunCm05AkSQNqzdKDZzqFx3AlWJIkSZ1jESxJkqTOsQiWJElS52xyRXCSt850DlMhybuSHDDNfR6dZFm7f3KSE6azf0mSpE3VJlcEA9NaBCeZtDcHrq+tqnp7VX1hsvqSJEnSxpvUIjjJ65OsSnJ9ko+1Y6cnOawv5r72dUGSy5Jcl+SGJPskWQo8rh07o8X9WTt/Q5I3t2MLk9yc5CPt+BlJDkhyRZJvJtmzxW2T5KNJViS5Nskr2/Gjk5yT5NPAxcPGsE2SC9sYbkhyeDu+e5JLk6xMclGSBe34l5P8bZJLgbclWZNks3Zu6yTfT7JF/zwk2SPJV1sfVyXZLsmcJKe0XFcl+cMNmOPfSfL1NsYvJHnqGN+n45Lc1No5a4O+yZIkSbPAZK6C7gK8DXhJVd2V5IljXHIkcFFVvTvJHGDrqro8yZuqanFrc3fgDcBvAAG+3orNHwO/BrwGOBZY0drbG3gFvdXkV7V8vlRVxySZD1yVZGg1di/geVX1o2F5vRy4raoObjnMS7IF8AHglVX1360wfjdwTLtmflW9tMW/EHgpcAnwO22MDyUZmqctgbOBw6tqRZLHAz8D/hdwb1XtkWQucEWSi6vqu+OY468AL6qqSvIHwInAn69n7k8CdqyqtW1eHiPJsW1umfP47dfTlCRJ0uCZzM8JfhlwblXdBTBCcTncCuCjrcA8v6quGyFmb+C8qrofIMmngH2AC4DvVtXqdvxG4IutCFwNLGzXHwS8om8v7FbAM9v9z4+S42rgvUneA3ymFea7ArsCn2/F7Bzg9r5rzh52/3B6RfARwAeHtf9s4PaqWgFQVT9pYzgIeF7fqvk8YBHw3b5rR5vjpwNnt9XpLYddM5JVwBlJzgfOHymgqpYDywHmLlhUY7QnSZI0UCZzO0SAkYqlh4f6Sa+C3BKgqi4D9gVuBT6W5PWjtDmatX33H+l7/Ai/LO4DHFpVi9vtmVX1X+3c/SM1WlXfAHanVwz/XZK3t3Zu7Gtnt6o6qO+y/rYuAH6rrdLuDnxphDGNNE8B/qSvjx2r6uJxXvsBYFlV7Qb8Ib1if30OBv6x5bdyMvdFS5IkDYLJLIK/CPxukicB9L1Uv4ZesQXwSmCLdv5XgTur6sPAvwAvbDEPtdVhgMuAV7W9tdsArwYu34CcLgL+pBXfJHnBWBckeRrwQFV9HHhvy+sWYPske7WYLdrWhMeoqvuAq4D30VtJXjcs5GbgaUn2aG1t14rQi4A/Hhp7kp3bmPuNNsfz6P1nAuCoMca3GfCMqrqE3raJ+cC267tGkiRptpm0FcCqujHJu4FLk6wDrgWOBj4M/EeSq+gVcUOrpvsBb0nyEHAfMLQSvBxYleSaqnptktPpFZUAH6mqa5MsHGda/xc4rbUXegX5IWNcsxtwSpJHgIeAP66qn7dtCu9PMo/evJ0G3DhKG2cD57QxPkpr63DgA0keR28/8AHAR+ht47im5frf9PY191872hyfDJyT5FbgSmDH9YxvDvDxNo4Ap1bVPeudEUmSpFkmVW731PrNXbCoFhx12kynIUmSBtSapQdPW19JVlbVkrHiNsXPCZYkSZKmlEWwJEmSOsdPBdCYdtthHldP48sYkiRJU82VYEmSJHWORbAkSZI6xyJYkiRJnWMRLEmSpM6xCJYkSVLnWARLkiSpc/yLcRpTkp8Ct8x0HjPsycBdM53EDHMOnANwDsA5GOI8OAewac7Br1bV9mMF+TnBGo9bxvPnB2ezJFc7B86Bc+AcgHMwxHlwDmCw58DtEJIkSeoci2BJkiR1jkWwxmP5TCewCXAOnANwDsA5AOdgiPPgHMAAz4FvjJMkSVLnuBIsSZKkzrEI7rAkL09yS5JvJTlphPNzk5zdzn89ycK+c3/Zjt+S5DenM+/JtrHzkOTAJCuTrG5fXzbduU+WifwstPPPTHJfkhOmK+fJNsHfh+cl+VqSG9vPw1bTmftkmcDvwhZJ/q2N/b+S/OV05z5ZxjEH+ya5JsnDSQ4bdu6oJN9st6OmL+vJtbFzkGRx3+/BqiSHT2/mk2ciPwft/OOT3Jpk2fRkPPkm+LvwzCQXt+eDm4b/m7HJqCpvHbwBc4BvA88CtgSuB547LOaNwD+1+0cAZ7f7z23xc4EdWztzZnpMMzAPLwCe1u7vCtw60+OZ7jnoO/9J4BzghJkezwz8HGwOrAKe3x4/aRB/HyY4B0cCZ7X7WwNrgIUzPaYpmoOFwPOAfwcO6zv+ROA77esT2v0nzPSYpnkOdgYWtftPA24H5s/0mKZzDvrOvw/4BLBspsczE3MAfBk4sN3fFth6psc00s2V4O7aE/hWVX2nqn4OnAW8cljMK4F/a/fPBf5HkrTjZ1XV2qr6LvCt1t4g2uh5qKprq+q2dvxGYKskc6cl68k1kZ8FkryK3j/4N05TvlNhInNwELCqqq4HqKq7q2rdNOU9mSYyBwVsk2Rz4HHAz4GfTE/ak2rMOaiqNVW1Cnhk2LW/CXy+qn5UVT8GPg+8fDqSnmQbPQdV9Y2q+ma7fxtwJzDmHyzYBE3k54AkuwNPBS6ejmSnyEbPQZLnAptX1edb3H1V9cA05b1BLIK7awfg+32Pf9COjRhTVQ8D99Jb5RrPtYNiIvPQ71Dg2qpaO0V5TqWNnoMk2wB/AbxzGvKcShP5OdgZqCQXtZcGT5yGfKfCRObgXOB+eit/3wPeW1U/muqEp8BEnttmy/PipIwjyZ70VhC/PUl5TaeNnoMkmwH/ALxlCvKaThP5OdgZuCfJp5Jcm+SUJHMmPcNJ4F+M666McGz4R4WMFjOeawfFROahdzLZBXgPvRXBQTSROXgncGpV3dcWhgfVROZgc2BvYA/gAeCLSVZW1RcnN8UpN5E52BNYR+8l8CcAlyf5QlV9Z3JTnHITeW6bLc+LEx5HkgXAx4CjquoxK6UDYCJz8EbgP6vq+x14ThzN5sA+9LYMfg84Gzga+JdJyWwSuRLcXT8AntH3+OnAbaPFtJc55wE/Gue1g2Ii80CSpwPnAa+vqkFc8YCJzcFvAH+fZA3wZuCtSd401QlPgYn+PlxaVXe1l/z+E3jhlGc8+SYyB0cCn6uqh6rqTuAKYBD/jOpEnttmy/PihMaR5PHAhcBfVdWVk5zbdJnIHOwFvKk9J74XeH2SpZOb3rSY6O/CtW0rxcPA+Wyiz4kWwd21AliUZMckW9J7k8sFw2IuAIbe4XwY8KXq7XK/ADiivVN8R2ARcNU05T3ZNnoeksyn92T/l1V1xbRlPPk2eg6qap+qWlhVC4HTgL+tqkF8N/REfh8uAp6XZOtWGL4UuGma8p5ME5mD7wEvS882wIuAm6cp78k0njkYzUXAQUmekOQJ9F4ZumiK8pxKGz0HLf484N+r6pwpzHGqbfQcVNVrq+qZ7TnxBHpz8ZhPVhgAE/ldWAE8IcnQfvCXsak+J870O/O8zdwN+G3gG/T2bL2tHXsX8Ip2fyt67/j/Fr0i91l9176tXXcL8FszPZaZmAfgr+jtg7yu7/aUmR7PdP8s9LVxMgP66RATnQPg9+m9MfAG4O9neizTPQf03v19TpuDm4C3zPRYpnAO9qC30nU/cDdwY9+1x7S5+Rbwhpkey3TPQfs9eGjYc+LimR7PdP8c9LVxNAP66RATnQPgQHqfmrMaOB3YcqbHM9LNvxgnSZKkznE7hCRJkjrHIliSJEmdYxEsSZKkzrEIliRJUudYBEuSJKlzLIIlSZLUORbBkiRJ6hyLYEmSJHXO/wfa3BSPQtIurQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 720x720 with 1 Axes>"
       ]
@@ -1807,173 +1838,6 @@
     "feat_importances = pd.Series(gbc.feature_importances_, index=df.columns)\n",
     "feat_importances = feat_importances.nlargest(19)\n",
     "feat_importances.plot(kind='barh' , figsize=(10,10)) "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Deploy Model to Watson Machine Learning service"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#hidden cell\n",
-    "wml_credentials = {\n",
-    "  \"apikey\": \"XXXXX\",\n",
-    "  \"iam_apikey_description\": \"Auto generated apikey during resource-key operation for Instance - crn:v1:bluemix:public:pm-20:us-south:a/47b84451ab70b94737518f7640a9ee42:4a7f62cc-XXXXX-8af4-b9f53533d2cf::\",\n",
-    "  \"iam_apikey_name\": \"auto-generated-apikey-8817c181-XXXXX-bb0a-01d12ef39eb9\",\n",
-    "  \"iam_role_crn\": \"crn:v1:bluemix:public:iam::::serviceRole:Writer\",\n",
-    "  \"iam_serviceid_crn\": \"crn:v1:bluemix:public:iam-identity::a/47b84451ab70b94737518f7640a9ee42::serviceid:ServiceId-222b7622-bac4-4c7f-889d-e793c57c7d62\",\n",
-    "  \"instance_id\": \"4a7f62cc-f564-4144-8af4-b9f53533d2cf\",\n",
-    "  \"password\": \"3e925562-XXXXX-99fe-4ed239d409a1\",\n",
-    "  \"url\": \"https://us-south.ml.cloud.ibm.com\",\n",
-    "  \"username\": \"8817c181-XXXXX-bb0a-01d12ef39eb9\"\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from watson_machine_learning_client import WatsonMachineLearningAPIClient\n",
-    "client = WatsonMachineLearningAPIClient(wml_credentials)\n",
-    "\n",
-    "meta_props={client.repository.ModelMetaNames.NAME: \"Gradient Boost model to predict customer churn\"}\n",
-    "published_model = client.repository.store_model(model=gbc, meta_props={client.repository.ModelMetaNames.NAME: \"Gradient Boost model to predict customer churn\"})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#get uid for the stored model\n",
-    "published_model_uid = client.repository.get_model_uid(published_model)\n",
-    "model_details = client.repository.get_details(published_model_uid)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "#######################################################################################\n",
-      "\n",
-      "Synchronous deployment creation for uid: 'be019a23-446e-43e7-ade1-d5a1333abb17' started\n",
-      "\n",
-      "#######################################################################################\n",
-      "\n",
-      "\n",
-      "INITIALIZING\n",
-      "DEPLOY_SUCCESS\n",
-      "\n",
-      "\n",
-      "------------------------------------------------------------------------------------------------\n",
-      "Successfully finished deployment creation, deployment_uid='36c7692b-df1e-493e-a833-7381c02aaf76'\n",
-      "------------------------------------------------------------------------------------------------\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "#create deployment\n",
-    "created_deployment = client.deployments.create(published_model_uid, name=\"customer_churn_model\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Score the deployed model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://us-south.ml.cloud.ibm.com/v3/wml_instances/4a7f62cc-f564-4144-8af4-b9f53533d2cf/deployments/36c7692b-df1e-493e-a833-7381c02aaf76/online\n"
-     ]
-    }
-   ],
-   "source": [
-    "#get scoring end point\n",
-    "scoring_endpoint = client.deployments.get_scoring_url(created_deployment)\n",
-    "print(scoring_endpoint)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Test data\n",
-    "scoring_payload = {'fields': ['state', 'account length', 'area code', 'international plan', 'voice mail plan',\n",
-    "        'number vmail messages', 'total day minutes', 'total day calls', 'total day charge', 'total eve minutes', 'total eve calls',\n",
-    "        'total eve charge', 'total night minutes', 'total night calls', 'total night charge', 'total intl minutes', 'total intl calls',\n",
-    "        'total intl charge', 'customer service calls'], \n",
-    "                   'values': [[10,161,415,0,0,0,332.9,67,56.59,317.8,97,27.01,160.6,128,7.23,5.4,9,1.46,4]]}\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "predictions = client.deployments.score(scoring_endpoint, scoring_payload)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "prediction {\n",
-      "  \"fields\": [\n",
-      "    \"prediction\",\n",
-      "    \"probability\"\n",
-      "  ],\n",
-      "  \"values\": [\n",
-      "    [\n",
-      "      1,\n",
-      "      [\n",
-      "        0.00021061113051734637,\n",
-      "        0.9997893888694827\n",
-      "      ]\n",
-      "    ]\n",
-      "  ]\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "import json\n",
-    "print('prediction',json.dumps(predictions, indent=2))"
    ]
   },
   {

--- a/notebooks/customer-churn-kaggle.ipynb
+++ b/notebooks/customer-churn-kaggle.ipynb
@@ -243,7 +243,9 @@
     "# State, international plans and voice mail plan are strings and we want discreet integer values\n",
     "df['state'] = label_encoder.fit_transform(df['state'])\n",
     "df['international plan'] = label_encoder.fit_transform(df['international plan'])\n",
-    "df['voice mail plan'] = label_encoder.fit_transform(df['voice mail plan'])"
+    "df['voice mail plan'] = label_encoder.fit_transform(df['voice mail plan'])\n",
+    "\n",
+    "print (df.dtypes)"
    ]
   },
   {
@@ -545,109 +547,6 @@
     "feat_importances = pd.Series(gbc.feature_importances_, index=df.columns)\n",
     "feat_importances = feat_importances.nlargest(19)\n",
     "feat_importances.plot(kind='barh' , figsize=(10,10)) "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Deploy Model to Watson Machine Learning service"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#hidden cell\n",
-    "wml_credentials = {\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from watson_machine_learning_client import WatsonMachineLearningAPIClient\n",
-    "client = WatsonMachineLearningAPIClient(wml_credentials)\n",
-    "\n",
-    "meta_props={client.repository.ModelMetaNames.NAME: \"Gradient Boost model to predict customer churn\"}\n",
-    "published_model = client.repository.store_model(model=gbc, meta_props={client.repository.ModelMetaNames.NAME: \"Gradient Boost model to predict customer churn\"})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#get uid for the stored model\n",
-    "published_model_uid = client.repository.get_model_uid(published_model)\n",
-    "model_details = client.repository.get_details(published_model_uid)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#create deployment\n",
-    "created_deployment = client.deployments.create(published_model_uid, name=\"customer_churn_model\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Score the deployed model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#get scoring end point\n",
-    "scoring_endpoint = client.deployments.get_scoring_url(created_deployment)\n",
-    "print(scoring_endpoint)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Test data\n",
-    "scoring_payload = {'fields': ['state', 'account length', 'area code', 'international plan', 'voice mail plan',\n",
-    "        'number vmail messages', 'total day minutes', 'total day calls', 'total day charge', 'total eve minutes', 'total eve calls',\n",
-    "        'total eve charge', 'total night minutes', 'total night calls', 'total night charge', 'total intl minutes', 'total intl calls',\n",
-    "        'total intl charge', 'customer service calls'], \n",
-    "                   'values': [[10,161,415,0,0,0,332.9,67,56.59,317.8,97,27.01,160.6,128,7.23,5.4,9,1.46,4]]}\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "predictions = client.deployments.score(scoring_endpoint, scoring_payload)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "print('prediction',json.dumps(predictions, indent=2))"
    ]
   },
   {


### PR DESCRIPTION
Reverts IBM/watson-studio-learning-path-assets#16

Revert back to notebook version without WML deployment